### PR TITLE
Remove dependency on EGL/KHR headers from README

### DIFF
--- a/inc/README.txt
+++ b/inc/README.txt
@@ -1,10 +1,10 @@
-Copy or symlink {OpenCL, EGL, KHR} headers here, inside appropriate
-directories, so that the structure of the inc directory looks something like
-this:
+Copy or symlink OpenCL headers here, inside a CL directory, so that
+the structure of the inc directory looks something like this:
 
 inc/CL/cl_d3d10.h
 inc/CL/cl_d3d11.h
 inc/CL/cl_dx9_media_sharing.h
+inc/CL/cl_egl.h
 inc/CL/cl_ext.h
 inc/CL/cl_gl_ext.h
 inc/CL/cl_gl.h
@@ -12,8 +12,3 @@ inc/CL/cl.h
 inc/CL/cl.hpp
 inc/CL/cl_platform.h
 inc/CL/opencl.h
-inc/EGL/eglext.h
-inc/EGL/egl.h
-inc/EGL/eglplatform.h
-inc/KHR/khrplatform.h
-


### PR DESCRIPTION
The EGL headers are no longer included by `CL/cl_egl.h`, as of [this commit](https://github.com/KhronosGroup/OpenCL-Headers/commit/c1770dcc6cf1daadec1905e7393f3691c1dde200), so we no longer need to instruct users to copy them into `inc/` in order to build the ICD loader.