### PR TITLE
correct the case that properties is NULL for clCreateContextFromType

### DIFF
--- a/icd.c
+++ b/icd.c
@@ -198,6 +198,12 @@ Done:
 
 void khrIcdContextPropertiesGetPlatform(const cl_context_properties *properties, cl_platform_id *outPlatform)
 {
+    if (properties == NULL && khrIcdVendors != NULL)
+    {
+        *outPlatform = khrIcdVendors[0].platform;
+        return;
+    }
+
     const cl_context_properties *property = (cl_context_properties *)NULL;
     *outPlatform = NULL;
     for (property = properties; property && property[0]; property += 2)

--- a/icd_dispatch.c
+++ b/icd_dispatch.c
@@ -218,11 +218,6 @@ clCreateContextFromType(const cl_context_properties * properties,
     // determine the platform to use from the properties specified
     khrIcdContextPropertiesGetPlatform(properties, &platform);
 
-    if (properties == NULL && khrIcdVendors != NULL)
-    {
-        platform = khrIcdVendors[0].platform;
-    }
-
     // validate the platform handle and dispatch
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clCreateContextFromType(

--- a/icd_dispatch.c
+++ b/icd_dispatch.c
@@ -218,6 +218,11 @@ clCreateContextFromType(const cl_context_properties * properties,
     // determine the platform to use from the properties specified
     khrIcdContextPropertiesGetPlatform(properties, &platform);
 
+    if (properties == NULL && khrIcdVendors != NULL)
+    {
+        platform = khrIcdVendors[0].platform;
+    }
+
     // validate the platform handle and dispatch
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clCreateContextFromType(


### PR DESCRIPTION
according to spec, for function clCreateContextFromType, properties
can also be NULL in which case the platform that is selected is
implementation-defined. While the current code returns CL_INVALID_PLATFORM.