### PR TITLE
Get vendor path from env var OPENCL_VENDOR_PATH, if it exists

### DIFF
--- a/icd_linux.c
+++ b/icd_linux.c
@@ -57,11 +57,17 @@ void khrIcdOsVendorsEnumerate(void)
 {
     DIR *dir = NULL;
     struct dirent *dirEntry = NULL;
+    char *vendorPath = NULL;
+
+    vendorPath = getenv("OPENCL_VENDOR_PATH");
+    if  (NULL == vendorPath)
+    {
 #ifdef __ANDROID__
-    char *vendorPath = "/system/vendor/Khronos/OpenCL/vendors/";
+        vendorPath = "/system/vendor/Khronos/OpenCL/vendors/";
 #else
-    char *vendorPath = "/etc/OpenCL/vendors/";
+        vendorPath = "/etc/OpenCL/vendors/";
 #endif // ANDROID
+    }
 
     // open the directory
     dir = opendir(vendorPath);


### PR DESCRIPTION
Allows behavior as described here: https://wiki.tiker.net/OpenCLHowTo#Per-user_ICD_registry.3F at least for Linux. If the env var `OPENCL_VENDOR_PATH` is not set, then it defaults to the previously hard-coded values.