### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 2.6)
 
 project (OPENCL_ICD_LOADER)
 
+option (TESTS "Enable building tests" ON)
+
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
@@ -27,5 +29,7 @@ endif ()
 
 target_link_libraries (OpenCL ${CMAKE_DL_LIBS})
 
-enable_testing()
-add_subdirectory (test)
+if (TESTS)
+    enable_testing ()
+    add_subdirectory (test)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 2.6)
 
 project (OPENCL_ICD_LOADER)
 
+option (BUILD_SHARED_LIBS "Build shared libs" ON)
 option (TESTS "Enable building tests" ON)
 
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -20,7 +21,7 @@ endif ()
 # OR copy OpenCL headers to ./inc/CL/
 include_directories (./inc)
 
-add_library (OpenCL SHARED ${OPENCL_ICD_LOADER_SOURCES})
+add_library (OpenCL ${OPENCL_ICD_LOADER_SOURCES})
 set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")

--- a/test/loader_test/CMakeLists.txt
+++ b/test/loader_test/CMakeLists.txt
@@ -12,4 +12,5 @@ add_executable (icd_loader_test
     test_clgl.c
     test_image_objects.c )
 
-target_link_libraries (icd_loader_test OpenCL IcdLog)
+find_package(Threads)
+target_link_libraries (icd_loader_test OpenCL IcdLog ${CMAKE_THREAD_LIBS_INIT})

--- a/test/loader_test/test_create_calls.c
+++ b/test/loader_test/test_create_calls.c
@@ -174,10 +174,15 @@ int test_clGetPlatformIDs(const struct clGetPlatformIDs_st* data)
                 &param_val_ret_size );  
 
         if (ret_val == CL_SUCCESS ){
-            if(!strcmp(platform_name, "ICD_LOADER_TEST_OPENCL_STUB")) {
+            if (!strcmp(platform_name, "ICD_LOADER_TEST_OPENCL_STUB")) {
                 platform = all_platforms[i];                
             }
         }
+    }
+
+    if (!platform) {
+        // The stub OpenCL not found.
+        return -2;
     }
 
 #if ENABLE_MISMATCHING_PRINTS

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -165,6 +165,11 @@ int test_clGetExtensionFunctionAddressForPlatform(const struct clGetExtensionFun
                      platform,  
                      data->func_name);
 
+    if (!platform) {
+        test_icd_app_log("No stub platform\n");
+        return -2;
+    }
+
     return_value=clGetExtensionFunctionAddressForPlatform(platform,
                                                         data->func_name);
 


### PR DESCRIPTION
This PR add option to disable build tests and to build the OpenCL ICD loaded as a static library.
It also fixes crashes in the icd_test_loader when it cannot find the test platform.