### PR TITLE
Update Windows DLL version to 2.2

### DIFF
--- a/OpenCL.rc
+++ b/OpenCL.rc
@@ -40,8 +40,8 @@
 #ifdef RC_INVOKED
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    2,1,0,0
-PRODUCTVERSION 2,1,0,0
+FILEVERSION    2,2,0,0
+PRODUCTVERSION 2,2,0,0
 FILETYPE       VFT_DLL
 
 BEGIN
@@ -52,7 +52,7 @@ BEGIN
             VALUE "FileDescription" ,"OpenCL Client DLL"
             VALUE "ProductName"     ,"Khronos OpenCL ICD"
             VALUE "LegalCopyright"  ,"Copyright \251 The Khronos Group Inc 2016"
-            VALUE "FileVersion"     ,"2.1.0.0"
+            VALUE "FileVersion"     ,"2.2.0.0"
 
             VALUE "CompanyName"     ,"Khronos Group"
             VALUE "InternalName"    ,"OpenCL"


### PR DESCRIPTION
This brings the OpenCL ICD DLL version in line with the latest version of OpenCL supported by the ICD.