### PR TITLE
Add Universal Windows Support to OpenCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
 else ()
-    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c OpenCL.def)
+    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.def)
     include_directories ($ENV{DXSDK_DIR}/Include)
 endif ()
 
@@ -27,6 +27,8 @@ set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread -Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map")
+else()
+    target_link_libraries (OpenCL setupapi.lib)
 endif ()
 
 target_link_libraries (OpenCL ${CMAKE_DL_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
 else ()
-    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.def)
+    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.def OpenCL.rc)
     include_directories ($ENV{DXSDK_DIR}/Include)
 endif ()
 

--- a/OpenCL.rc
+++ b/OpenCL.rc
@@ -40,8 +40,8 @@
 #ifdef RC_INVOKED
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    2,2,0,0
-PRODUCTVERSION 2,2,0,0
+FILEVERSION    2,2,1,0
+PRODUCTVERSION 2,2,1,0
 FILETYPE       VFT_DLL
 
 BEGIN
@@ -52,8 +52,7 @@ BEGIN
             VALUE "FileDescription" ,"OpenCL Client DLL"
             VALUE "ProductName"     ,"Khronos OpenCL ICD"
             VALUE "LegalCopyright"  ,"Copyright \251 The Khronos Group Inc 2016"
-            VALUE "FileVersion"     ,"2.2.0.0"
-
+            VALUE "FileVersion"     ,"2.2.1.0"
             VALUE "CompanyName"     ,"Khronos Group"
             VALUE "InternalName"    ,"OpenCL"
             VALUE "OriginalFilename","OpenCL.dll"

--- a/icd.c
+++ b/icd.c
@@ -58,6 +58,7 @@ void khrIcdVendorAdd(const char *libraryName)
     cl_uint i = 0;
     cl_uint platformCount = 0;
     cl_platform_id *platforms = NULL;
+    KHRicdVendor *vendorIterator = NULL;
 
     // require that the library name be valid
     if (!libraryName) 
@@ -72,6 +73,16 @@ void khrIcdVendorAdd(const char *libraryName)
     {
         KHR_ICD_TRACE("failed to load library %s\n", libraryName);
         goto Done;
+    }
+
+    // ensure that we haven't already loaded this vendor
+    for (vendorIterator = khrIcdVendors; vendorIterator; vendorIterator = vendorIterator->next)
+    {
+        if (vendorIterator->library == library)
+        {
+            KHR_ICD_TRACE("already loaded vendor %s, nothing to do here\n", libraryName);
+            goto Done;
+        }
     }
 
     // get the library's clGetExtensionFunctionAddress pointer

--- a/icd_windows.c
+++ b/icd_windows.c
@@ -36,6 +36,7 @@
  */
 
 #include "icd.h"
+#include "icd_windows_hkr.h"
 #include <stdio.h>
 #include <windows.h>
 #include <winreg.h>
@@ -56,6 +57,11 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
     const char* platformsName = "SOFTWARE\\Khronos\\OpenCL\\Vendors";
     HKEY platformsKey = NULL;
     DWORD dwIndex;
+
+    if (!khrIcdOsVendorsEnumerateHKR())
+    {
+        KHR_ICD_TRACE("Failed to enumerate HKR entries, continuing\n");
+    }
 
     KHR_ICD_TRACE("Opening key HKLM\\%s...\n", platformsName);
     result = RegOpenKeyExA(

--- a/icd_windows_hkr.c
+++ b/icd_windows_hkr.c
@@ -41,12 +41,11 @@
 #include <SetupAPI.h>
 #include <devguid.h>
 
-#define KHR_SAFE_RELEASE(mem)         \
-    do                                \
-    {                                 \
-        if (mem)                      \
-            free(mem);                \
-        mem = NULL;                   \
+#define KHR_SAFE_RELEASE(mem)       \
+    do                              \
+    {                               \
+        free(mem);                  \
+        mem = NULL;                 \
     } while (0)
 
 static const char HKR_PREFIX[] = "SYSTEM\\CurrentControlSet\\Control\\Class\\";

--- a/icd_windows_hkr.c
+++ b/icd_windows_hkr.c
@@ -52,7 +52,7 @@ static const char HKR_PREFIX[] = "SYSTEM\\CurrentControlSet\\Control\\Class\\";
 #ifdef _WIN64
 static const char OPENCL_REG_SUB_KEY[] = "OpenCLDriverName";
 #else
-static const char OPENCL_REG_SUB_KEY[] = "OpenCLDriverNameWow"
+static const char OPENCL_REG_SUB_KEY[] = "OpenCLDriverNameWow";
 #endif
 
 // Given a display adapter HKR (GUID\000x), returns the full registry path

--- a/icd_windows_hkr.c
+++ b/icd_windows_hkr.c
@@ -49,7 +49,7 @@
         mem = NULL;                   \
     } while (0)
 
-static const char HKR_PREFIX[] = "SYSTEM\\ControlSet001\\Control\\Class\\";
+static const char HKR_PREFIX[] = "SYSTEM\\CurrentControlSet\\Control\\Class\\";
 #ifdef _WIN64
 static const char OPENCL_REG_SUB_KEY[] = "OpenCLDriverName";
 #else

--- a/icd_windows_hkr.c
+++ b/icd_windows_hkr.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2017 The Khronos Group Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software source and associated documentation files (the "Materials"),
+ * to deal in the Materials without restriction, including without limitation
+ * the rights to use, copy, modify, compile, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Materials, and to permit persons to
+ * whom the Materials are furnished to do so, subject the following terms and
+ * conditions:
+ *
+ * All modifications to the Materials used to create a binary that is
+ * distributed to third parties shall be provided to Khronos with an
+ * unrestricted license to use for the purposes of implementing bug fixes and
+ * enhancements to the Materials;
+ *
+ * If the binary is used as part of an OpenCL(TM) implementation, whether binary
+ * is distributed together with or separately to that implementation, then
+ * recipient must become an OpenCL Adopter and follow the published OpenCL
+ * conformance process for that implementation, details at:
+ * http://www.khronos.org/conformance/;
+ *
+ * The above copyright notice, the OpenCL trademark license, and this permission
+ * notice shall be included in all copies or substantial portions of the
+ * Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS IN
+ * THE MATERIALS.
+ *
+ * OpenCL is a trademark of Apple Inc. used under license by Khronos.
+ */
+
+#include "icd.h"
+#include "icd_windows_hkr.h"
+#include <windows.h>
+#include <SetupAPI.h>
+#include <devguid.h>
+
+#define KHR_SAFE_RELEASE(mem)         \
+    do                                \
+    {                                 \
+        if (mem)                      \
+            free(mem);                \
+        mem = NULL;                   \
+    } while (0)
+
+static const char HKR_PREFIX[] = "SYSTEM\\ControlSet001\\Control\\Class\\";
+#ifdef _WIN64
+static const char OPENCL_REG_SUB_KEY[] = "OpenCLDriverName";
+#else
+static const char OPENCL_REG_SUB_KEY[] = "OpenCLDriverNameWow"
+#endif
+
+// Given a display adapter HKR (GUID\000x), returns the full registry path
+// to that adapter (i.e. SYSTEM\...\Class\GUID\000x).
+static char* khrGetFullHKRPath(const char* hkr)
+{
+    char* cszHkrFullPath;
+    size_t szHkrFullPath;
+    errno_t ret;
+
+    szHkrFullPath = (sizeof(HKR_PREFIX) - 1) + strlen(hkr) + 1;
+    cszHkrFullPath = malloc(szHkrFullPath);
+    if (!cszHkrFullPath)
+    {
+        KHR_ICD_TRACE("failed to allocate memory\n");
+        return NULL;
+    }
+
+    RtlZeroMemory(cszHkrFullPath, szHkrFullPath);
+
+    ret = strcat_s(cszHkrFullPath, szHkrFullPath, HKR_PREFIX);
+    KHR_ICD_ASSERT(ret == 0);
+    ret = strcat_s(cszHkrFullPath, szHkrFullPath, hkr);
+    KHR_ICD_ASSERT(ret == 0);
+
+    return cszHkrFullPath;
+}
+
+// Returns a string property for a device or NULL otherwise.
+// Caller must release the buffer returned by this function.
+static char* khrGetDeviceStringProperty(
+    HDEVINFO deviceInfoSet,
+    PSP_DEVINFO_DATA deviceInfoData,
+    DWORD dwProperty)
+{
+    char* cszProperty;
+    DWORD dwPropertySize;
+    DWORD dwReqSize;
+    DWORD dwDataType;
+
+    dwPropertySize = 1024;
+    cszProperty = malloc(dwPropertySize);
+    if (!cszProperty)
+    {
+        KHR_ICD_TRACE("failed to allocate memory\n");
+        return NULL;
+    }
+
+    while (!SetupDiGetDeviceRegistryProperty(
+        deviceInfoSet,
+        deviceInfoData,
+        dwProperty,
+        &dwDataType,
+        (LPBYTE)cszProperty,
+        dwPropertySize,
+        &dwReqSize))
+    {
+        if (ERROR_INSUFFICIENT_BUFFER != GetLastError())
+        {
+            goto failed;
+        }
+
+        if (REG_SZ != dwDataType)
+        {
+            goto failed;
+        }
+
+        dwPropertySize = dwReqSize;
+        free(cszProperty);
+        cszProperty = malloc(dwPropertySize);
+        if (!cszProperty)
+        {
+            KHR_ICD_TRACE("failed to allocate memory\n");
+            goto failed;
+        }
+    }
+
+    return cszProperty;
+
+failed:
+    if (cszProperty)
+    {
+        free(cszProperty);
+    }
+
+    return NULL;
+}
+
+// Enumerates each of the vendors (display adapters) HKR entries
+// and searches for OpenCLDriverName entry.
+BOOL CALLBACK khrIcdOsVendorsEnumerateHKR(void)
+{
+    SP_DEVINFO_DATA deviceInfoData = { 0 };
+    HDEVINFO deviceInfoSet;
+    DWORD dwError;
+    DWORD dwDeviceIndex = 0;
+    char *hwId, *devDesc, *hkr, *fullHkr;
+    HKEY hkrKey = NULL;
+
+    deviceInfoSet = SetupDiGetClassDevs(
+        &GUID_DEVCLASS_DISPLAY,
+        NULL,
+        NULL,
+        DIGCF_PRESENT);
+
+    KHR_ICD_ASSERT(INVALID_HANDLE_VALUE != deviceInfoSet);
+
+    if (INVALID_HANDLE_VALUE == deviceInfoSet)
+    {
+        dwError = GetLastError();
+        KHR_ICD_TRACE("Failed to get display adapter class device instance %d\n", dwError);
+        return FALSE;
+    }
+
+    deviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+
+    hwId = devDesc = hkr = fullHkr = NULL;
+
+    KHR_ICD_TRACE("Enumerating OpenCL ICDs HKR entries...\n");
+
+    while (SetupDiEnumDeviceInfo(
+        deviceInfoSet,
+        dwDeviceIndex,
+        &deviceInfoData))
+    {
+        LSTATUS result;
+        DWORD dwLibraryNameType = 0;
+        char cszOclPath[MAX_PATH] = { '\0' };
+        DWORD dwOclPathSize = sizeof(cszOclPath);
+
+        dwDeviceIndex++;
+
+        hwId = khrGetDeviceStringProperty(
+            deviceInfoSet,
+            &deviceInfoData,
+            SPDRP_HARDWAREID);
+
+        if (!hwId)
+        {
+            KHR_ICD_TRACE("Failed to get HW ID, continuing\n");
+            goto NextIter;
+        }
+
+        devDesc = khrGetDeviceStringProperty(
+            deviceInfoSet,
+            &deviceInfoData,
+            SPDRP_FRIENDLYNAME);
+
+        if (!devDesc)
+        {
+            devDesc = khrGetDeviceStringProperty(
+                deviceInfoSet,
+                &deviceInfoData,
+                SPDRP_DEVICEDESC);
+        }
+
+        if (!devDesc)
+        {
+            KHR_ICD_TRACE("Failed to get device description, continuing\n");
+            goto NextIter;
+        }
+
+        hkr = khrGetDeviceStringProperty(
+            deviceInfoSet,
+            &deviceInfoData,
+            SPDRP_DRIVER);
+
+        if (!hkr)
+        {
+            KHR_ICD_TRACE("Failed to get HKR, continuing\n");
+            goto NextIter;
+        }
+
+        fullHkr = khrGetFullHKRPath(hkr);
+        if (!fullHkr)
+        {
+            KHR_ICD_TRACE("Failed to get fullHkr, continuing\n");
+            goto NextIter;
+        }
+
+        // FIXME: we only really care about `hkr` and `fullHkr`, the rest is nice for
+        //        diagnostics but probably should not be fetched (for performance).
+        KHR_ICD_TRACE("%d) Device HW ID: %s\n", dwDeviceIndex, hwId);
+        KHR_ICD_TRACE("   Device Description: %s\n", devDesc);
+        KHR_ICD_TRACE("   HKR: %s\n\n", hkr);
+        KHR_ICD_TRACE("   Full HKR: %s\n\n", fullHkr);
+
+        KHR_ICD_TRACE("Opening key %s...\n", fullHkr);
+        result = RegOpenKeyEx(
+            HKEY_LOCAL_MACHINE,
+            fullHkr,
+            0,
+            KEY_READ,
+            &hkrKey);
+        if (ERROR_SUCCESS != result)
+        {
+            KHR_ICD_TRACE("Failed to open key %s, continuing\n", fullHkr);
+            goto NextIter;
+        }
+
+        result = RegQueryValueEx(
+            hkrKey,
+            OPENCL_REG_SUB_KEY,
+            NULL,
+            &dwLibraryNameType,
+            (LPBYTE)cszOclPath,
+            &dwOclPathSize);
+        if (ERROR_SUCCESS != result)
+        {
+            KHR_ICD_TRACE("Failed to open sub key %s, continuing\n", OPENCL_REG_SUB_KEY);
+            goto NextIter;
+        }
+
+        result = RegCloseKey(hkrKey);
+        if (ERROR_SUCCESS != result)
+        {
+            KHR_ICD_TRACE("Failed to close sub key %s, ignoring\n", OPENCL_REG_SUB_KEY);
+        }
+
+        if (REG_MULTI_SZ != dwLibraryNameType)
+        {
+            KHR_ICD_TRACE("Unexpected registry entry! continuing\n");
+            goto NextIter;
+        }
+        KHR_ICD_TRACE("   Value: %s\n\n", cszOclPath);
+
+        khrIcdVendorAdd(cszOclPath);
+
+    NextIter:
+        KHR_SAFE_RELEASE(hwId);
+        KHR_SAFE_RELEASE(devDesc);
+        KHR_SAFE_RELEASE(hkr);
+        KHR_SAFE_RELEASE(fullHkr);
+    }
+
+    KHR_ICD_ASSERT(ERROR_NO_MORE_ITEMS == GetLastError() &&
+                   "Device enumeration failed unexpectedly");
+
+    if (deviceInfoSet)
+        (void)SetupDiDestroyDeviceInfoList(deviceInfoSet);
+
+    return TRUE;
+}

--- a/icd_windows_hkr.h
+++ b/icd_windows_hkr.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017 The Khronos Group Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software source and associated documentation files (the "Materials"),
+ * to deal in the Materials without restriction, including without limitation
+ * the rights to use, copy, modify, compile, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Materials, and to permit persons to
+ * whom the Materials are furnished to do so, subject the following terms and
+ * conditions:
+ *
+ * All modifications to the Materials used to create a binary that is
+ * distributed to third parties shall be provided to Khronos with an
+ * unrestricted license to use for the purposes of implementing bug fixes and
+ * enhancements to the Materials;
+ *
+ * If the binary is used as part of an OpenCL(TM) implementation, whether binary
+ * is distributed together with or separately to that implementation, then
+ * recipient must become an OpenCL Adopter and follow the published OpenCL
+ * conformance process for that implementation, details at:
+ * http://www.khronos.org/conformance/;
+ *
+ * The above copyright notice, the OpenCL trademark license, and this permission
+ * notice shall be included in all copies or substantial portions of the
+ * Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS IN
+ * THE MATERIALS.
+ *
+ * OpenCL is a trademark of Apple Inc. used under license by Khronos.
+ */
+
+#include "icd.h"
+#include <windows.h>
+
+BOOL CALLBACK khrIcdOsVendorsEnumerateHKR(void);


### PR DESCRIPTION
**TL;DR: OpenCL ICD Loader now enumerates HKR registry keys (see below)
in addition to "Khronos\OpenCL\Vendors" registry key.**

Starting from Microsoft Windows 10 RS3/RS4 (Redstone), the Universal INF
does not support AddReg directives to HKLM, and instead require that
drivers nest driver-specific keys under their assigned HKR key.

This patch adds OpenCL platforms enumeration under display adapter HKR
keys, namely under:
HKLM\SYSTEM\ControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0000\OpenCLDriverName[Wow]
...
HKLM\SYSTEM\ControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\000N\OpenCLDriverName[Wow]

Similar to how OpenGL ICDs are detected on Windows by the OpenGL ICD Loader.

This is done *in addition* to the old school "Khronos\OpenCL\Vendors"
enumeration in order to remain backward compatible with older drivers, as
well as other non Graphics Drivers vendors (e.g. Intel OpenCL Experimental
Platform, intelopencl64_2_1.dll).