### PR TITLE
Remove GL/EGL headers

### DIFF
--- a/icd_dispatch.c
+++ b/icd_dispatch.c
@@ -1666,7 +1666,7 @@ clGetExtensionFunctionAddress(const char *function_name) CL_EXT_SUFFIX__VERSION_
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLBuffer(
     cl_context    context,
     cl_mem_flags  flags,
-    GLuint        bufobj,
+    cl_GLuint     bufobj,
     int *         errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
@@ -1698,9 +1698,9 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture(
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture2D(
     cl_context      context,
     cl_mem_flags    flags,
-    GLenum          target,
-    GLint           miplevel,
-    GLuint          texture,
+    cl_GLenum       target,
+    cl_GLint        miplevel,
+    cl_GLuint       texture,
     cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
@@ -1716,9 +1716,9 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture2D(
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture3D(
     cl_context      context,
     cl_mem_flags    flags,
-    GLenum          target,
-    GLint           miplevel,
-    GLuint          texture,
+    cl_GLenum       target,
+    cl_GLint        miplevel,
+    cl_GLuint       texture,
     cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
@@ -1734,7 +1734,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture3D(
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer(
     cl_context           context,
     cl_mem_flags         flags,
-    GLuint               renderbuffer,
+    cl_GLuint            renderbuffer,
     cl_int *             errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
@@ -1748,7 +1748,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer(
 CL_API_ENTRY cl_int CL_API_CALL clGetGLObjectInfo(
     cl_mem               memobj,
     cl_gl_object_type *  gl_object_type,
-    GLuint *             gl_object_name) CL_API_SUFFIX__VERSION_1_0
+    cl_GLuint *          gl_object_name) CL_API_SUFFIX__VERSION_1_0
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clGetGLObjectInfo(

--- a/icd_dispatch.h
+++ b/icd_dispatch.h
@@ -66,11 +66,6 @@
 #include <CL/cl_d3d11.h>
 #include <CL/cl_dx9_media_sharing.h>
 #endif
-#if !defined(__ANDROID__)
-#include <GL/gl.h>
-#else
-#include <GLES/gl.h>
-#endif
 #include <CL/cl_gl.h>
 #include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
@@ -801,7 +796,7 @@ typedef CL_API_ENTRY void * (CL_API_CALL *KHRpfn_clGetExtensionFunctionAddress)(
 typedef CL_API_ENTRY cl_mem (CL_API_CALL *KHRpfn_clCreateFromGLBuffer)(
     cl_context    context,
     cl_mem_flags  flags,
-    GLuint        bufobj,
+    cl_GLuint     bufobj,
     int *         errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 typedef CL_API_ENTRY cl_mem (CL_API_CALL *KHRpfn_clCreateFromGLTexture)(
@@ -815,29 +810,29 @@ typedef CL_API_ENTRY cl_mem (CL_API_CALL *KHRpfn_clCreateFromGLTexture)(
 typedef CL_API_ENTRY cl_mem (CL_API_CALL *KHRpfn_clCreateFromGLTexture2D)(
     cl_context      context,
     cl_mem_flags    flags,
-    GLenum          target,
-    GLint           miplevel,
-    GLuint          texture,
+    cl_GLenum       target,
+    cl_GLint        miplevel,
+    cl_GLuint       texture,
     cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 typedef CL_API_ENTRY cl_mem (CL_API_CALL *KHRpfn_clCreateFromGLTexture3D)(
     cl_context      context,
     cl_mem_flags    flags,
-    GLenum          target,
-    GLint           miplevel,
-    GLuint          texture,
+    cl_GLenum       target,
+    cl_GLint        miplevel,
+    cl_GLuint       texture,
     cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 typedef CL_API_ENTRY cl_mem (CL_API_CALL *KHRpfn_clCreateFromGLRenderbuffer)(
     cl_context           context,
     cl_mem_flags         flags,
-    GLuint               renderbuffer,
+    cl_GLuint            renderbuffer,
     cl_int *             errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 typedef CL_API_ENTRY cl_int (CL_API_CALL *KHRpfn_clGetGLObjectInfo)(
     cl_mem               memobj,
     cl_gl_object_type *  gl_object_type,
-    GLuint *             gl_object_name) CL_API_SUFFIX__VERSION_1_0;
+    cl_GLuint *          gl_object_name) CL_API_SUFFIX__VERSION_1_0;
                   
 typedef CL_API_ENTRY cl_int (CL_API_CALL *KHRpfn_clGetGLTextureInfo)(
     cl_mem               memobj,

--- a/test/loader_test/param_struct.h
+++ b/test/loader_test/param_struct.h
@@ -5,11 +5,6 @@
 #include<CL/cl_gl.h>
 #include<CL/cl_gl_ext.h>
 
-#ifdef _WIN32
-#include <windows.h> /* Needed for gl.h */
-#endif
-#include<GL/gl.h>
-
 struct clCreateCommandQueue_st
 {
     cl_context context;
@@ -930,7 +925,7 @@ struct clCreateFromGLBuffer_st
 {
     cl_context context;
     cl_mem_flags flags; 
-    GLuint bufobj; 
+    cl_GLuint bufobj; 
     int *errcode_ret;
 };
 
@@ -942,9 +937,9 @@ struct clCreateFromGLTexture_st
 {
     cl_context context;
     cl_mem_flags flags; 
-    GLenum texture_target;
-    GLint miplevel; 
-    GLuint texture; 
+    cl_GLenum texture_target;
+    cl_GLint miplevel; 
+    cl_GLuint texture; 
     cl_int *errcode_ret;
 };
 
@@ -952,9 +947,9 @@ struct clCreateFromGLTexture2D_st
 {
     cl_context context;
     cl_mem_flags flags; 
-    GLenum texture_target;
-    GLint miplevel; 
-    GLuint texture; 
+    cl_GLenum texture_target;
+    cl_GLint miplevel; 
+    cl_GLuint texture; 
     cl_int *errcode_ret;
 };
 
@@ -962,9 +957,9 @@ struct clCreateFromGLTexture3D_st
 {
     cl_context context;
     cl_mem_flags flags; 
-    GLenum texture_target;
-    GLint miplevel; 
-    GLuint texture; 
+    cl_GLenum texture_target;
+    cl_GLint miplevel; 
+    cl_GLuint texture; 
     cl_int *errcode_ret;
 };
 
@@ -974,7 +969,7 @@ struct clCreateFromGLRenderbuffer_st
 {
     cl_context context; 
     cl_mem_flags flags;
-    GLuint renderbuffer; 
+    cl_GLuint renderbuffer; 
     cl_int *errcode_ret;
 };
   
@@ -987,7 +982,7 @@ struct clGetGLObjectInfo_st
 {
     cl_mem memobj;
     cl_gl_object_type *gl_object_type; 
-    GLuint *gl_object_name;
+    cl_GLuint *gl_object_name;
 };
 
 struct clGetGLTextureInfo_st 


### PR DESCRIPTION
Remove GL/EGL headers from the ICD and replace GL types with typedefs from cl_platform.h.

The ICD requires only 3 GL types for CL/GL sharing related functions:
- GLenum
- GLint
- GLuint

All of these types are already mirrored in [cl_platform.h](https://github.com/KhronosGroup/OpenCL-Headers/blob/master/opencl22/CL/cl_platform.h#L409), so there is no point in including GL/EGL again. This way GL/EGL headers are no more required to build the ICD.

What's more, [clCreateFromGLTexture](https://github.com/KhronosGroup/OpenCL-ICD-Loader/blob/master/icd_dispatch.h#L807) is already using the mirrored types.