### PR TITLE
Support building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,11 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
 
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
-else ()
+if (WIN32)
     list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.def OpenCL.rc)
     include_directories ($ENV{DXSDK_DIR}/Include)
+else ()
+    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
 endif ()
 
 # Change this to point to a directory containing OpenCL header directory "CL"
@@ -25,10 +25,14 @@ include_directories (${OPENCL_INCLUDE_DIRS})
 add_library (OpenCL SHARED ${OPENCL_ICD_LOADER_SOURCES})
 set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
 
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread -Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map")
-else()
+if (WIN32)
     target_link_libraries (OpenCL cfgmgr32.lib)
+else()
+    if (APPLE)
+        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread")
+    else ()
+        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread -Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map")
+    endif ()
 endif ()
 
 target_link_libraries (OpenCL ${CMAKE_DL_LIBS})

--- a/test/loader_test/icd_test_match.c
+++ b/test/loader_test/icd_test_match.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <string.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <platform/icd_test_log.h>
 
 int test_icd_match()


### PR DESCRIPTION
Use the the linux code in that case.

The resulting library hasn't been tested but it is already
useful as is as a library to link against to build-test
things like the CTS on macOS.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>