### PR TITLE
Update icd_windows_hkr.c

### DIFF
--- a/icd_windows_hkr.c
+++ b/icd_windows_hkr.c
@@ -147,7 +147,7 @@ static bool ReadOpenCLKey(DEVINST dnDevNode)
             goto out;
         }
 
-        if (REG_SZ != dwLibraryNameType)
+        if (REG_SZ != dwLibraryNameType && REG_MULTI_SZ != dwLibraryNameType)
         {
             KHR_ICD_TRACE("Unexpected registry entry 0x%x! continuing\n", dwLibraryNameType);
             goto out;


### PR DESCRIPTION
Recent AMD drivers write "OpenCLDriverName" registry value as REG_MULTI_SZ (with only one string in it).