### PR TITLE
Update icd_windows.c

### DIFF
--- a/icd_windows.c
+++ b/icd_windows.c
@@ -73,7 +73,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
     if (ERROR_SUCCESS != result)
     {
         KHR_ICD_TRACE("Failed to open platforms key %s, continuing\n", platformsName);
-        return FALSE;
+        return TRUE;
     }
 
     // for each value


### PR DESCRIPTION
Return TRUE from khrIcdOsVendorsEnumerate() even if RegOpenKeyExA() fails to open the key.