### PR TITLE
Do parameter validation in clGetExtensionFunctionAddress

### DIFF
--- a/icd_dispatch.c
+++ b/icd_dispatch.c
@@ -1359,6 +1359,8 @@ CL_API_ENTRY void * CL_API_CALL
 clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
                                          const char *   function_name) CL_API_SUFFIX__VERSION_1_2
 {
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(function_name, NULL);
+
     // make sure the ICD is initialized
     khrIcdInitialize();    
 
@@ -1425,6 +1427,8 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
 
     /* cl_khr_sub_groups */
     CL_COMMON_EXTENSION_ENTRYPOINT_ADD(clGetKernelSubGroupInfoKHR);
+
+    #undef CL_COMMON_EXTENSION_ENTRYPOINT_ADD
 
     // This is not an ICD-aware extension, so call into the implementation
     // to get the extension function address.
@@ -1567,11 +1571,14 @@ clEnqueueBarrier(cl_command_queue command_queue) CL_EXT_SUFFIX__VERSION_1_1_DEPR
 CL_API_ENTRY void * CL_API_CALL
 clGetExtensionFunctionAddress(const char *function_name) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
 {
-    size_t function_name_length = strlen(function_name);
+    size_t function_name_length = 0;
     KHRicdVendor* vendor = NULL;
+
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(function_name, NULL);
 
     // make sure the ICD is initialized
     khrIcdInitialize();    
+    function_name_length = strlen(function_name);
 
     // return any ICD-aware extensions
 
@@ -1636,6 +1643,8 @@ clGetExtensionFunctionAddress(const char *function_name) CL_EXT_SUFFIX__VERSION_
 
     /* cl_khr_sub_groups */
     CL_COMMON_EXTENSION_ENTRYPOINT_ADD(clGetKernelSubGroupInfoKHR);
+
+    #undef CL_COMMON_EXTENSION_ENTRYPOINT_ADD
 
     // fall back to vendor extension detection
     for (vendor = khrIcdVendors; vendor; vendor = vendor->next)


### PR DESCRIPTION
Also undefine the local macros as soon as possible.

Patch originally from Jeroen Ketema.  I have recreated this change to (a) rebase against other changes since the change was original made, and (b) to allow myself to sign the CLA so that the change can be accepted (Jeroen Ketema was an employee of Codeplay Software at the time that the change was written, and I am a current employee of Codeplay Software).