### PR TITLE
simple travis CI enabling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+
+compiler:
+  - gcc
+  #- clang
+
+os:
+  - linux
+  #- osx
+
+before_install:
+  - git clone https://github.com/KhronosGroup/OpenCL-Headers inc/OpenCL-Headers
+
+script:
+  - mkdir -p build
+  - cd build
+  - cmake -DOPENCL_ICD_LOADER_HEADERS_DIR=../inc/OpenCL-Headers ..
+  - make


### PR DESCRIPTION
Support for basic travis-ci, for builds only.  I've enabled gcc and Linux.  It should be trivial to enable CLANG and/or OSX as well, if desired.  We'll need a bit more work to enable testing, due to the current manual configuration required (and modification of system folders).

Example travis-ci build (this is on my fork, we'll need to enable this repo also):

https://travis-ci.org/bashbaug/OpenCL-ICD-Loader
