### PR TITLE
basic appveyor enabling

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,20 @@
+os:
+  - Visual Studio 2017
+  #- Visual Studio 2015
+
+platform:
+  - Win32
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+before_build:
+  - git clone --depth=1 https://github.com/KhronosGroup/OpenCL-Headers inc/OpenCL-Headers
+  - cmake -DOPENCL_ICD_LOADER_HEADERS_DIR=inc/OpenCL-Headers -H. -Bbuild -A%PLATFORM%
+
+build:
+  project: build\OPENCL_ICD_LOADER.sln
+  parallel: true
+  verbosity: normal


### PR DESCRIPTION
Support for basic Appveyor, for builds only.  I've enabled Visual Studio 2017, for 32-bit and 64-bit builds, for Debug and Release configurations.  

We'll need a bit more work to enable testing, due to the current manual configuration required (and modification of system folders).

Example Appveyor build:

https://ci.appveyor.com/project/bashbaug/opencl-icd-loader

Note, there are quite a few warnings on the Appveyor build, but it does succeed.  We can address the warnings as a follow-on change.
