### PR TITLE
Downstream MinGW fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (WIN32)
     # Only add the DXSDK include directory if the environment variable is
     # defined.  Since the DXSDK has merged into the Windows SDK, this is
     # only required in rare cases.
-    if (DEFINED ENV{DXSDK_DIR})
+    if (DEFINED ENV{DXSDK_DIR} AND NOT (MINGW OR MSYS OR CYGWIN))
         include_directories ($ENV{DXSDK_DIR}/Include)
     endif ()
 else ()

--- a/loader/windows/icd_windows_hkr.c
+++ b/loader/windows/icd_windows_hkr.c
@@ -23,7 +23,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <initguid.h>
-#include <Devpkey.h>
+#include <devpkey.h>
 #include <devguid.h>
 
  // This GUID was only added to devguid.h on Windows SDK v10.0.16232 which


### PR DESCRIPTION
* Don't include DX SDK at all on MinGW (MinGW have their own headers)
* Lower case header name for cross-compilation on Linux

This PR does **not** fix #11, but contains the fixes required on our side to make it build again once upstream problems are worked around or fixed.

See also [this upstream mailing list thread](https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/CAJ127VwoVEXkZETwzowxXw-fK2O6sLmZF-6Si-7rM5E4q-efCw%40mail.gmail.com/).