### PR TITLE
Add Travis + AppVeyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,72 @@
+linux: &linux
+  os: linux
+  dist: xenial
+  language: python
+  python: "3.7"
+  services:
+    - docker
+osx: &osx
+  os: osx
+  language: generic
+matrix:
+  include:
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=4.9 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc49-armv7hf
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=5 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc5-armv7hf
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=6 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc6-armv7hf
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=7 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc7-armv7hf
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=8 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc8-armv7hf
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=5 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc5-armv8
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=6 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc6-armv8
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=7 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc7-armv8
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=8 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc8-armv8
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
+    - <<: *linux
+      env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
+    - <<: *linux
+      env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
+    - <<: *linux
+      env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
+    - <<: *linux
+      env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
+    - <<: *linux
+      env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
+    - <<: *linux
+      env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
+    - <<: *linux
+      env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
+    - <<: *osx
+      osx_image: xcode8.3
+      env: CONAN_APPLE_CLANG_VERSIONS=8.1
+    - <<: *osx
+      osx_image: xcode9
+      env: CONAN_APPLE_CLANG_VERSIONS=9.0
+    - <<: *osx
+      osx_image: xcode9.4
+      env: CONAN_APPLE_CLANG_VERSIONS=9.1
+    - <<: *osx
+      osx_image: xcode10.1
+      env: CONAN_APPLE_CLANG_VERSIONS=10.0
+
+install:
+  - chmod +x .travis/install.sh
+  - ./.travis/install.sh
+
+script:
+  - chmod +x .travis/run.sh
+  - ./.travis/run.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || brew upgrade cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 3.7.1
+    pyenv virtualenv 3.7.1 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install conan --upgrade
+pip install conan_package_tools
+
+conan user

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+python build.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ find_package (Threads REQUIRED)
 # advance. Use it with discretion.
 option (BUILD_SHARED_LIBS "Build shared libs" ON)
 
+if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 set (OPENCL_ICD_LOADER_SOURCES
     loader/icd.c
     loader/icd_dispatch.c)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+build: false
+
+environment:
+    PYTHON: "C:\\Python37"
+    
+    matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+
+install:
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
+  - pip.exe install conan --upgrade
+  - pip.exe install conan_package_tools
+  - conan user # It creates the conan data directory
+
+test_script:
+- python build.py

--- a/build.py
+++ b/build.py
@@ -1,0 +1,11 @@
+from cpt.packager import ConanMultiPackager
+import datetime
+
+if __name__ == "__main__":
+    builder = ConanMultiPackager(
+    	username="khronos",
+    	login_username="khronos",
+    	channel="stable"
+	)
+    builder.add_common_builds()
+    builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,47 @@
+from conans import ConanFile, CMake, tools
+import os
+import shutil
+
+
+class KhronosopenclicdloaderConan(ConanFile):
+    name = "khronos-opencl-icd-loader"
+    version = "20190508"
+    license = "Apache-2.0"
+    author = "Khronos Group <webmaster@khronos.org"
+    url = "https://github.com/KhronosGroup/opencl-icd-loader"
+    description = "The OpenCL ICD Loader"
+    topics = ("khronos", "opencl", "icd", "icd-loader")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"fPIC": [True, False], "shared": [True, False]}
+    default_options = {"fPIC": True, "shared": True}
+    generators = "cmake"
+
+    exports_sources = "inc/*", "loader/*", "test/*", "CMakeLists.txt"
+    
+    def imports(self):
+        commit = "master"
+        url = "https://github.com/KhronosGroup/opencl-headers/archive/{0}.tar.gz".format(commit)
+        tools.get(url)
+        extracted_dir = "OpenCL-Headers-" + commit
+        dest = os.path.join(self.source_folder, "inc")
+        shutil.rmtree(dest)
+        shutil.move(extracted_dir, dest)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["USE_DYNAMIC_VCXX_RUNTIME"] = False
+        cmake.configure()
+        cmake.build()
+        # cmake.test()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.extend(["pthread", "dl"])
+        elif self.settings.os == "Windows" and \
+            self.settings.get_safe("os.subsystem") != "wsl":
+            self.cpp_info.libs.append("cfgmgr32")
+
+    def configure(self):
+        del self.settings.compiler.libcxx

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(PackageTest C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.c)
+target_link_libraries(example ${CONAN_LIBS})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,22 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class KhronosopenclicdloaderTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/test_package/example.c
+++ b/test_package/example.c
@@ -1,0 +1,17 @@
+#if defined(_WIN32)
+    #define CL_API_ENTRY
+    #define CL_API_CALL     __stdcall
+    #define CL_CALLBACK     __stdcall
+#else
+    #define CL_API_ENTRY
+    #define CL_API_CALL
+    #define CL_CALLBACK
+#endif
+
+CL_API_ENTRY void *CL_API_CALL clGetExtensionFunctionAddress(char const *);
+
+int main(void) {
+	void * (CL_API_CALL *KHRpfn_clGetExtensionFunctionAddress)(const char *) = 
+	        clGetExtensionFunctionAddress;
+	return 0;
+}


### PR DESCRIPTION
Though #62 and #63 are up for review already, I'd also like to submit my take on adding CI to the ICD loader, since this is in use successfully over at [bincrafters/conan-khronos-opencl-icd-loader](https://github.com/bincrafters/conan-khronos-opencl-icd-loader) already for generating ICD binary artifacts.

This matrix uses the Conan Package Tools to build **significantly** more configurations:

- **Architectures**: x86, x86_64, armv7hf, armv8
- **Operating Systems**: Linux, Windows, macOS (MinGW requires patches, that's why I haven't added it to this matrix)
- **Compilers**:
    - gcc 4.9 to 8 (I'll add 9 once there's a Docker image available)
    - clang 3.9 to 8
    - Apple Clang 8.1 to 10.0
    - VS 2013 to 2017 (2019 will be added once AppVeyor supports it)
- **Build Configuration**: Debug, Release (on Windows with the different runtimes set)
- **Library Type**: Static, Shared

Since almost all permutations of above matrix are built, this sums up to >150 builds and should give us a very nice coverage.

### RFC
- Should we keep macOS builds? We all now Apple's stance on OpenCL, sadly. It builds just fine at the moment, but the question is whether we should continue to test for it.
- Inside of the conanfile I download the OpenCL Headers from master. I'm not exactly a fan of this, as changes on the headers may manifest in failed CI on unrelated changes on the ICD, resulting in unnecessary blockages.
    - We have an OpenCL Header package on Conan which we could use
    - Alternatively we could pin the commit hash and update it manually from time to time
