### PR TITLE
Upgrade to CMake 3.1, CMake + PkgConfig packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required (VERSION 2.8.11)
-
-project (OPENCL_ICD_LOADER)
-find_package (Threads REQUIRED)
+cmake_minimum_required (VERSION 3.1)
+project (OPENCL_ICD_LOADER VERSION 1.2 LANGUAGES C)
 
 # The option below allows building the ICD Loader library as a shared library
 # (ON, default) or a static library (OFF).
@@ -33,66 +31,51 @@ find_package (Threads REQUIRED)
 # advance. Use it with discretion.
 option (BUILD_SHARED_LIBS "Build shared libs" ON)
 
-set (OPENCL_ICD_LOADER_SOURCES
-    loader/icd.c
-    loader/icd_dispatch.c)
+set (CMAKE_C_STANDARD 99)
+set (CMAKE_C_STANDARD_REQUIRED ON)
+set (CMAKE_C_EXTENSIONS OFF)
 
-if (WIN32)
-    list (APPEND OPENCL_ICD_LOADER_SOURCES 
-        loader/windows/icd_windows.c
-        loader/windows/icd_windows_hkr.c
-        loader/windows/OpenCL.def
-        loader/windows/OpenCL.rc)
-    # Only add the DXSDK include directory if the environment variable is
-    # defined.  Since the DXSDK has merged into the Windows SDK, this is
-    # only required in rare cases.
-    if (DEFINED ENV{DXSDK_DIR} AND NOT (MINGW OR MSYS OR CYGWIN))
-        include_directories ($ENV{DXSDK_DIR}/Include)
-    endif ()
-else ()
-    list (APPEND OPENCL_ICD_LOADER_SOURCES
-        loader/linux/icd_linux.c
-        loader/linux/icd_exports.map)
+if (WIN32 AND NOT USE_DYNAMIC_VCXX_RUNTIME)
+    string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+    string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
+    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}")
+    string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/MDd" "/MTd" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/MDd" "/MTd" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 endif ()
 
-set (OPENCL_ICD_LOADER_HEADERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/inc CACHE PATH "Path to OpenCL Headers")
-
-add_library (OpenCL ${OPENCL_ICD_LOADER_SOURCES})
-set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
-
-if (WIN32)
-    target_link_libraries (OpenCL cfgmgr32.lib)
-    if(NOT USE_DYNAMIC_VCXX_RUNTIME)
-        string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-        string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-        string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
-        string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}")
-        string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-        string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-        string(REPLACE "/MDd" "/MTd" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-        string(REPLACE "/MDd" "/MTd" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-    endif()
-else()
-    if (APPLE)
-        target_link_libraries (OpenCL ${CMAKE_THREAD_LIBS_INIT})
-    else ()
-        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/loader/linux/icd_exports.map")
-        target_link_libraries (OpenCL ${CMAKE_THREAD_LIBS_INIT})
-    endif ()
-endif ()
-
-include_directories (${OPENCL_ICD_LOADER_HEADERS_DIR})
-add_definitions (-DCL_TARGET_OPENCL_VERSION=220)
-
-target_include_directories (OpenCL PRIVATE loader)
-target_link_libraries (OpenCL ${CMAKE_DL_LIBS})
+add_subdirectory (loader)
 
 include (CTest)
 if (BUILD_TESTING)
     add_subdirectory (test)
 endif()
 
-install (TARGETS OpenCL
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib)
+export(EXPORT OpenCLTargets
+  FILE "${PROJECT_BINARY_DIR}/OpenCL/OpenCLTargets.cmake"
+  NAMESPACE OpenCL::)
+configure_file(cmake/OpenCLConfig.cmake
+  "${PROJECT_BINARY_DIR}/OpenCL/OpenCLConfig.cmake"
+  COPYONLY)
+
+set(config_package_location lib/cmake/OpenCL)
+install(EXPORT OpenCLTargets
+  FILE OpenCLTargets.cmake
+  NAMESPACE OpenCL::
+  DESTINATION ${config_package_location})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCL/OpenCLConfig.cmake
+  DESTINATION ${config_package_location}
+  COMPONENT Devel)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/OpenCLConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/OpenCLConfigVersion.cmake"
+  DESTINATION ${config_package_location}
+  COMPONENT Devel)

--- a/cmake/OpenCLConfig.cmake
+++ b/cmake/OpenCLConfig.cmake
@@ -1,0 +1,7 @@
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads REQUIRED)
+find_dependency(OpenCLHeaders REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpenCLTargets.cmake")

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -1,0 +1,38 @@
+find_package (Threads REQUIRED)
+find_package (OpenCLHeaders REQUIRED)
+
+add_library(OpenCL
+    icd.h icd.c
+    icd_dispatch.h icd_dispatch.c
+)
+
+set_target_properties(OpenCL PROPERTIES
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    VERSION ${PROJECT_VERSION}
+)
+
+target_link_libraries(OpenCL
+    PUBLIC Threads::Threads OpenCL::OpenCLHeaders ${CMAKE_DL_LIBS})
+target_compile_definitions(OpenCL PRIVATE CL_TARGET_OPENCL_VERSION=220)
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    add_subdirectory(windows)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    add_subdirectory(linux)
+endif()
+
+install (TARGETS OpenCL EXPORT OpenCLTargets
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)
+
+if (UNIX)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/OpenCL.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/OpenCL.pc.configured
+        @ONLY)
+    file(GENERATE
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/OpenCL.pc
+      INPUT ${CMAKE_CURRENT_BINARY_DIR}/OpenCL.pc.configured)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCL.pc DESTINATION lib/pkgconfig)
+endif()

--- a/loader/OpenCL.pc.in
+++ b/loader/OpenCL.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=$<TARGET_PROPERTY:OpenCL::OpenCLHeaders,INTERFACE_INCLUDE_DIRECTORIES>
+
+Name: OpenCL
+Description: OpenCL Installable Client Driver Loader
+Version: @PROJECT_VERSION@
+Libs: ${libdir}/$<TARGET_LINKER_FILE_NAME:OpenCL> @CMAKE_THREAD_LIBS_INIT@ -l@CMAKE_DL_LIBS@
+Cflags: -I$<JOIN:$<TARGET_PROPERTY:OpenCL,INTERFACE_INCLUDE_DIRECTORIES>, -I>

--- a/loader/linux/CMakeLists.txt
+++ b/loader/linux/CMakeLists.txt
@@ -1,0 +1,12 @@
+target_sources(OpenCL PRIVATE
+    linux/icd_linux.c
+    linux/icd_exports.map
+)
+
+target_compile_definitions(OpenCL PRIVATE _DEFAULT_SOURCE)
+set_property(TARGET OpenCL APPEND PROPERTY
+    LINK_FLAGS -Wl,--version-script="${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map"
+)
+set_property(TARGET OpenCL APPEND PROPERTY
+    LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map"
+)

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -16,7 +16,7 @@
  * OpenCL is a trademark of Apple Inc. used under license by Khronos.
  */
 
-#include "icd.h"
+#include "../icd.h"
 #include <dlfcn.h>
 #include <stdio.h>
 #include <string.h>

--- a/loader/windows/CMakeLists.txt
+++ b/loader/windows/CMakeLists.txt
@@ -1,0 +1,15 @@
+target_sources(OpenCL PRIVATE
+    windows/icd_windows.c
+    windows/icd_windows_hkr.c
+    windows/OpenCL.def
+    windows/OpenCL.rc
+)
+
+# Only add the DXSDK include directory if the environment variable is
+# defined.  Since the DXSDK has merged into the Windows SDK, this is
+# only required in rare cases.
+if (DEFINED ENV{DXSDK_DIR} AND NOT (MINGW OR MSYS OR CYGWIN))
+    target_include_directories(OpenCL PRIVATE $ENV{DXSDK_DIR}/Include)
+endif ()
+
+target_link_libraries(OpenCL PUBLIC cfgmgr32)

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -16,7 +16,7 @@
  * OpenCL is a trademark of Apple Inc. used under license by Khronos.
  */
 
-#include "icd.h"
+#include "../icd.h"
 #include "icd_windows_hkr.h"
 #include <stdio.h>
 #include <windows.h>

--- a/loader/windows/icd_windows_hkr.c
+++ b/loader/windows/icd_windows_hkr.c
@@ -16,7 +16,7 @@
  * OpenCL is a trademark of Apple Inc. used under license by Khronos.
  */
 
-#include "icd.h"
+#include "../icd.h"
 #include "icd_windows_hkr.h"
 #include <windows.h>
 #include <cfgmgr32.h>


### PR DESCRIPTION
As promised, here's a PR that upgrades the CMake scripts to v3.1. Improvements that mandate the version bump include:

* Installs a OpenCLConfig.cmake. This makes the Kitware-supplied `FindOpenCL.cmake` inside the CMake standard distribution obsolete. `find_package(OpenCL NO_MODULE)` would define a target that properly adds libdl and pthread as (transitive) dependencies.
* Installs  a OpenCL.pc. Many people who don't use CMake would like to have a PkgConfig file instead
* Depend on the OpenCL headers through the `find_package` mechanism.
    * **This approach is blocked by KhronosGroup/OpenCL-Headers#47**. An alternative would be a `FindOpenCLHeader.cmake`, but that would also have to be installed and maintained.
    * **RFC: I've dropped the old copy/paste approach** This can be readded if desired.
* Properly set `CMAKE_C_STANDARD`. This is important for certain compilers that default to C89 (MinGW gcc 4.9 in particular).