### PR TITLE
Add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+---
+Checks:          '*,-android-cloexec-fopen,-misc-unused-parameters'
+WarningsAsErrors: 'readability-inconsistent-declaration-parameter-name,hicpp-braces-around-statements,bugprone-macro-parentheses,bugprone-suspicious-string-compare'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle: file
+CheckOptions:    
+  - key: readability-inconsistent-declaration-parameter-name.Strict
+    value: 1
+...
+

--- a/loader/icd.c
+++ b/loader/icd.c
@@ -167,8 +167,10 @@ void khrIcdVendorAdd(const char *libraryName)
 
         // add this vendor to the list of vendors at the tail
         {
-            KHRicdVendor **prevNextPointer = NULL;
-            for (prevNextPointer = &khrIcdVendors; *prevNextPointer; prevNextPointer = &( (*prevNextPointer)->next) );
+            KHRicdVendor **prevNextPointer = &khrIcdVendors;
+            while(*prevNextPointer) {
+                prevNextPointer = &( (*prevNextPointer)->next);
+            }
             *prevNextPointer = vendor;
         }
 

--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -128,17 +128,17 @@ clGetDeviceInfo(
 CL_API_ENTRY cl_int CL_API_CALL
 clCreateSubDevices(cl_device_id                         in_device,
                    const cl_device_partition_property * properties,
-                   cl_uint                              num_entries,
+                   cl_uint                              num_devices,
                    cl_device_id *                       out_devices,
-                   cl_uint *                            num_devices) CL_API_SUFFIX__VERSION_1_2
+                   cl_uint *                            num_devices_ret) CL_API_SUFFIX__VERSION_1_2
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(in_device, CL_INVALID_DEVICE);
     return in_device->dispatch->clCreateSubDevices(
         in_device,
         properties,
-        num_entries,
+        num_devices,
         out_devices,
-        num_devices);
+        num_devices_ret);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL
@@ -823,7 +823,7 @@ clEnqueueReadBuffer(cl_command_queue    command_queue,
                     cl_mem              buffer,
                     cl_bool             blocking_read,
                     size_t              offset,
-                    size_t              cb, 
+                    size_t              size, 
                     void *              ptr,
                     cl_uint             num_events_in_wait_list,
                     const cl_event *    event_wait_list,
@@ -835,7 +835,7 @@ clEnqueueReadBuffer(cl_command_queue    command_queue,
         buffer,
         blocking_read,
         offset,
-        cb, 
+        size, 
         ptr,
         num_events_in_wait_list,
         event_wait_list,
@@ -847,8 +847,8 @@ clEnqueueReadBufferRect(
     cl_command_queue command_queue,
     cl_mem buffer,
     cl_bool blocking_read,
-    const size_t * buffer_origin,
-    const size_t * host_origin, 
+    const size_t * buffer_offset,
+    const size_t * host_offset, 
     const size_t * region,
     size_t buffer_row_pitch,
     size_t buffer_slice_pitch,
@@ -864,8 +864,8 @@ clEnqueueReadBufferRect(
         command_queue,
         buffer,
         blocking_read,
-        buffer_origin,
-        host_origin, 
+        buffer_offset,
+        host_offset, 
         region,
         buffer_row_pitch,
         buffer_slice_pitch,
@@ -882,7 +882,7 @@ clEnqueueWriteBuffer(cl_command_queue   command_queue,
                      cl_mem             buffer, 
                      cl_bool            blocking_write, 
                      size_t             offset, 
-                     size_t             cb, 
+                     size_t             size, 
                      const void *       ptr, 
                      cl_uint            num_events_in_wait_list, 
                      const cl_event *   event_wait_list, 
@@ -894,7 +894,7 @@ clEnqueueWriteBuffer(cl_command_queue   command_queue,
         buffer, 
         blocking_write, 
         offset, 
-        cb, 
+        size, 
         ptr, 
         num_events_in_wait_list, 
         event_wait_list, 
@@ -905,9 +905,9 @@ CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueWriteBufferRect(
     cl_command_queue command_queue,
     cl_mem buffer,
-    cl_bool blocking_read,
-    const size_t * buffer_origin,
-    const size_t * host_origin, 
+    cl_bool blocking_write,
+    const size_t * buffer_offset,
+    const size_t * host_offset, 
     const size_t * region,
     size_t buffer_row_pitch,
     size_t buffer_slice_pitch,
@@ -922,9 +922,9 @@ clEnqueueWriteBufferRect(
     return command_queue->dispatch->clEnqueueWriteBufferRect(
         command_queue,
         buffer,
-        blocking_read,
-        buffer_origin,
-        host_origin, 
+        blocking_write,
+        buffer_offset,
+        host_offset, 
         region,
         buffer_row_pitch,
         buffer_slice_pitch,
@@ -942,7 +942,7 @@ clEnqueueFillBuffer(cl_command_queue   command_queue,
                     const void *       pattern, 
                     size_t             pattern_size, 
                     size_t             offset, 
-                    size_t             cb, 
+                    size_t             size, 
                     cl_uint            num_events_in_wait_list, 
                     const cl_event *   event_wait_list, 
                     cl_event *         event) CL_API_SUFFIX__VERSION_1_2
@@ -954,7 +954,7 @@ clEnqueueFillBuffer(cl_command_queue   command_queue,
         pattern, 
         pattern_size,
         offset,
-        cb, 
+        size, 
         num_events_in_wait_list,
         event_wait_list,
         event);
@@ -966,7 +966,7 @@ clEnqueueCopyBuffer(cl_command_queue    command_queue,
                     cl_mem              dst_buffer, 
                     size_t              src_offset,
                     size_t              dst_offset,
-                    size_t              cb, 
+                    size_t              size, 
                     cl_uint             num_events_in_wait_list,
                     const cl_event *    event_wait_list,
                     cl_event *          event) CL_API_SUFFIX__VERSION_1_0
@@ -978,7 +978,7 @@ clEnqueueCopyBuffer(cl_command_queue    command_queue,
         dst_buffer, 
         src_offset,
         dst_offset,
-        cb, 
+        size, 
         num_events_in_wait_list,
         event_wait_list,
         event);
@@ -1173,7 +1173,7 @@ clEnqueueMapBuffer(cl_command_queue command_queue,
                    cl_bool          blocking_map, 
                    cl_map_flags     map_flags,
                    size_t           offset,
-                   size_t           cb,
+                   size_t           size,
                    cl_uint          num_events_in_wait_list,
                    const cl_event * event_wait_list,
                    cl_event *       event,
@@ -1186,7 +1186,7 @@ clEnqueueMapBuffer(cl_command_queue command_queue,
         blocking_map, 
         map_flags,
         offset,
-        cb,
+        size,
         num_events_in_wait_list,
         event_wait_list,
         event,
@@ -1357,9 +1357,9 @@ clEnqueueBarrierWithWaitList(cl_command_queue  command_queue,
 
 CL_API_ENTRY void * CL_API_CALL
 clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
-                                         const char *   function_name) CL_API_SUFFIX__VERSION_1_2
+                                         const char *   func_name) CL_API_SUFFIX__VERSION_1_2
 {
-    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(function_name, NULL);
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(func_name, NULL);
 
     // make sure the ICD is initialized
     khrIcdInitialize();    
@@ -1370,7 +1370,7 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
     // do not need to be ICD-aware and do not require any ICD loader
     // modifications.  The KHR and EXT extensions below were added for
     // backwards compatibility only.
-    #define CL_COMMON_EXTENSION_ENTRYPOINT_ADD(name) if (!strcmp(function_name, #name) ) return (void *)(size_t)&name
+    #define CL_COMMON_EXTENSION_ENTRYPOINT_ADD(name) if (!strcmp(func_name, #name) ) return ((void *)(size_t)&(name))
 
     // Functions supporting the creation of OpenCL Memory Objects
     // from OpenGL Objects (cl_apple_gl_sharing, cl_khr_gl_sharing)
@@ -1436,7 +1436,7 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, NULL);
     return platform->dispatch->clGetExtensionFunctionAddressForPlatform(
         platform,
-        function_name);
+        func_name);
 }
 
 // Deprecated APIs
@@ -1457,7 +1457,7 @@ clSetCommandQueueProperty(cl_command_queue              command_queue,
 CL_API_ENTRY cl_int CL_API_CALL
 clCreateSubDevicesEXT(
     cl_device_id in_device,
-    const cl_device_partition_property_ext * partition_properties,
+    const cl_device_partition_property_ext * properties,
     cl_uint num_entries,
     cl_device_id * out_devices,
     cl_uint * num_devices) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
@@ -1465,7 +1465,7 @@ clCreateSubDevicesEXT(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(in_device, CL_INVALID_DEVICE);
         return in_device->dispatch->clCreateSubDevicesEXT(
         in_device,
-        partition_properties,
+        properties,
         num_entries,
         out_devices,
         num_devices);
@@ -1569,16 +1569,16 @@ clEnqueueBarrier(cl_command_queue command_queue) CL_EXT_SUFFIX__VERSION_1_1_DEPR
 }
 
 CL_API_ENTRY void * CL_API_CALL
-clGetExtensionFunctionAddress(const char *function_name) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+clGetExtensionFunctionAddress(const char *func_name) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
 {
     size_t function_name_length = 0;
     KHRicdVendor* vendor = NULL;
 
-    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(function_name, NULL);
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(func_name, NULL);
 
     // make sure the ICD is initialized
     khrIcdInitialize();    
-    function_name_length = strlen(function_name);
+    function_name_length = strlen(func_name);
 
     // return any ICD-aware extensions
 
@@ -1586,7 +1586,7 @@ clGetExtensionFunctionAddress(const char *function_name) CL_EXT_SUFFIX__VERSION_
     // do not need to be ICD-aware and do not require any ICD loader
     // modifications.  The KHR and EXT extensions below were added for
     // backwards compatibility only.
-    #define CL_COMMON_EXTENSION_ENTRYPOINT_ADD(name) if (!strcmp(function_name, #name) ) return (void *)(size_t)&name
+    #define CL_COMMON_EXTENSION_ENTRYPOINT_ADD(name) if (!strcmp(func_name, #name) ) return ((void *)(size_t)&(name))
 
     // Functions supporting the creation of OpenCL Memory Objects
     // from OpenGL Objects (cl_apple_gl_sharing, cl_khr_gl_sharing)
@@ -1652,10 +1652,10 @@ clGetExtensionFunctionAddress(const char *function_name) CL_EXT_SUFFIX__VERSION_
         size_t vendor_suffix_length = strlen(vendor->suffix);
         if (vendor_suffix_length <= function_name_length && vendor_suffix_length > 0)
         {            
-            const char *function_suffix = function_name+function_name_length-vendor_suffix_length;
+            const char *function_suffix = func_name+function_name_length-vendor_suffix_length;
             if (!strcmp(function_suffix, vendor->suffix) )
             {
-                return vendor->clGetExtensionFunctionAddress(function_name);
+                return vendor->clGetExtensionFunctionAddress(func_name);
             }
         }
     }
@@ -1835,13 +1835,13 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
 
 CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
 	cl_context context,
-	cl_GLsync sync,
+	cl_GLsync cl_GLsync,
 	cl_int * errcode_ret) CL_API_SUFFIX__VERSION_1_1
 {
 	KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
 	return context->dispatch->clCreateEventFromGLsyncKHR(
 		context,
-		sync,
+		cl_GLsync,
 		errcode_ret);
 }
 
@@ -2232,8 +2232,8 @@ clSetUserEventStatus(
 CL_API_ENTRY cl_mem CL_API_CALL
 clCreateFromEGLImageKHR(
     cl_context context,
-    CLeglDisplayKHR display,
-    CLeglImageKHR image,
+    CLeglDisplayKHR egldisplay,
+    CLeglImageKHR eglimage,
     cl_mem_flags flags,
     const cl_egl_image_properties_khr *properties,
     cl_int *errcode_ret)
@@ -2241,8 +2241,8 @@ clCreateFromEGLImageKHR(
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromEGLImageKHR(
         context,
-        display,
-        image,
+        egldisplay,
+        eglimage,
         flags,
         properties,
         errcode_ret);

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -17,13 +17,13 @@
  */
 
 #include "icd.h"
-#include <dlfcn.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <sys/types.h>
 #include <dirent.h>
+#include <dlfcn.h>
 #include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
 
 static pthread_once_t initialized = PTHREAD_ONCE_INIT;
 
@@ -72,7 +72,7 @@ void khrIcdOsVendorsEnumerate(void)
                 {
                     break;
                 }
-                if (strcmp(dirEntry->d_name + strlen(dirEntry->d_name) - strlen(extension), extension) ) 
+                if (strcmp(dirEntry->d_name + strlen(dirEntry->d_name) - strlen(extension), extension) != 0) 
                 {
                     break;
                 }
@@ -113,7 +113,10 @@ void khrIcdOsVendorsEnumerate(void)
                     break;
                 }
                 // ignore a newline at the end of the file
-                if (buffer[bufferSize-1] == '\n') buffer[bufferSize-1] = '\0';
+                if (buffer[bufferSize-1] == '\n')
+                {
+                    buffer[bufferSize-1] = '\0';
+                }
 
                 // load the string read from the file
                 khrIcdVendorAdd(buffer);

--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifndef CL_USE_DEPRECATED_OPENCL_1_0_APIS
@@ -14,13 +14,13 @@
 // themselves via the dispatch table. Include this before cl headers.
 #include "rename_api.h"
 
+#include "icd_structs.h"
 #include <CL/cl.h>
 #include <platform/icd_test_log.h>
-#include "icd_structs.h"
 
 #define CL_PLATFORM_ICD_SUFFIX_KHR                  0x0920
 CL_API_ENTRY cl_int CL_API_CALL
-clIcdGetPlatformIDsKHR(cl_uint, cl_platform_id *, cl_uint *);
+clIcdGetPlatformIDsKHR(cl_uint /*num_entries*/, cl_platform_id * /*platforms*/, cl_uint * /*num_platforms*/);
 
 struct _cl_platform_id
 {
@@ -863,7 +863,7 @@ clLinkProgram(cl_context            context ,
               void *                user_data ,
               cl_int *              errcode_ret) CL_API_SUFFIX__VERSION_1_2
 {
-    cl_program obj = (cl_program) malloc(sizeof(cl_program));
+    cl_program obj = (cl_program) malloc(sizeof(*obj));
     obj->dispatch = dispatchTable;
     test_icd_stub_log("clLinkProgram(%p, %u, %p, %p, %u, %p, %p, %p, %p)\n",
                       context,
@@ -1598,7 +1598,7 @@ clEnqueueMapBuffer(cl_command_queue  command_queue ,
                    cl_event *        event ,
                    cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
-    void *return_value = (void *) malloc(sizeof(void *));
+    void *return_value = malloc(sizeof(void *));
     test_icd_stub_log("clEnqueueMapBuffer(%p, %p, %u, %x, %u, %u, %u, %p, %p, %p)\n",
                       command_queue,
                       buffer,
@@ -1629,7 +1629,7 @@ clEnqueueMapImage(cl_command_queue   command_queue ,
                   cl_event *         event ,
                   cl_int *           errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
-    void *return_value = (void *) malloc(sizeof(void *));
+    void *return_value = malloc(sizeof(void *));
     test_icd_stub_log("clEnqueueMapImage(%p, %p, %u, %x, %p, %p, %p, %p, %u, %p, %p, %p)\n",
                       command_queue,
                       image,
@@ -1772,7 +1772,7 @@ CL_API_ENTRY void * CL_API_CALL
 clGetExtensionFunctionAddressForPlatform(cl_platform_id  platform ,
                                          const char *    func_name) CL_API_SUFFIX__VERSION_1_2
 {
-    void *return_value = (void *) malloc(sizeof(void *));
+    void *return_value = malloc(sizeof(void *));
     test_icd_stub_log("clGetExtensionFunctionAddressForPlatform(%p, %p)\n",
                       platform,
                       func_name);

--- a/test/driver_stub/cl_gl.c
+++ b/test/driver_stub/cl_gl.c
@@ -111,7 +111,7 @@ clGetGLObjectInfo(cl_mem                 memobj,
                   cl_gl_object_type *    gl_object_type,
                   cl_GLuint *            gl_object_name ) CL_API_SUFFIX__VERSION_1_0
 {  
-     cl_int ret_val = -5;
+     cl_int ret_val = CL_OUT_OF_RESOURCES;
      test_icd_stub_log("clGetGLObjectInfo(%p, %p, %p)\n",
                        memobj,
                        gl_object_type,
@@ -128,7 +128,7 @@ clGetGLTextureInfo(cl_mem                memobj,
                    void *                param_value,
                    size_t *              param_value_size_ret ) CL_API_SUFFIX__VERSION_1_0
 {
-     cl_int ret_val = -5;
+     cl_int ret_val = CL_OUT_OF_RESOURCES;
      test_icd_stub_log("clGetGLTextureInfo(%p, %u, %u, %p, %p)\n",
                        memobj,
                        param_name,
@@ -148,7 +148,7 @@ clEnqueueAcquireGLObjects(cl_command_queue       command_queue,
                           const cl_event *       event_wait_list,
                           cl_event *             event ) CL_API_SUFFIX__VERSION_1_0
 {
-    cl_int ret_val = -5;
+    cl_int ret_val = CL_OUT_OF_RESOURCES;
     test_icd_stub_log("clEnqueueAcquireGLObjects(%p, %u, %p, %u, %p, %p)\n",
                       command_queue,
                       num_objects,
@@ -171,7 +171,7 @@ clEnqueueReleaseGLObjects(cl_command_queue       command_queue,
                           cl_event *             event ) CL_API_SUFFIX__VERSION_1_0
 
 {
-     cl_int ret_val = -5;
+     cl_int ret_val = CL_OUT_OF_RESOURCES;
      test_icd_stub_log("clEnqueueReleaseGLObjects(%p, %u, %p, %u, %p, %p)\n",
                         command_queue,
                         num_objects,
@@ -191,7 +191,7 @@ clGetGLContextInfoKHR(const cl_context_properties *  properties,
                       void *                         param_value,
                       size_t *                       param_value_size_ret ) CL_API_SUFFIX__VERSION_1_0
 {
-    cl_int ret_val = -5;
+    cl_int ret_val = CL_OUT_OF_RESOURCES;
     test_icd_stub_log("clGetGLContextInfoKHR(%p, %u, %u, %p, %p)\n",
                       properties,
                       param_name,

--- a/test/driver_stub/icd.c
+++ b/test/driver_stub/icd.c
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <assert.h>
 #include "icd_structs.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS

--- a/test/loader_test/callbacks.c
+++ b/test/loader_test/callbacks.c
@@ -1,6 +1,6 @@
 #include <CL/cl.h>
-#include <stdio.h>
 #include <platform/icd_test_log.h>
+#include <stdio.h>
 
 void CL_CALLBACK createcontext_callback(const char* _a, const void* _b, size_t _c, void* _d)
 {

--- a/test/loader_test/icd_test_match.c
+++ b/test/loader_test/icd_test_match.c
@@ -8,7 +8,8 @@
 int test_icd_match()
 {
     int error = 0;
-    char *app_log = NULL, *stub_log = NULL;
+    char *app_log = NULL;
+    char *stub_log = NULL;
 
     app_log = test_icd_get_app_log();
     if (!app_log) {
@@ -24,7 +25,7 @@ int test_icd_match()
         goto End;
     }
 
-    if (strcmp(app_log, stub_log)) {
+    if (strcmp(app_log, stub_log) != 0) {
         printf("ERROR: App log and stub log differ.\n");
         error = 1;
         goto End;

--- a/test/loader_test/main.c
+++ b/test/loader_test/main.c
@@ -1,7 +1,7 @@
-#include<stdio.h>
+#include "param_struct.h"
 #include<CL/cl.h>
 #include<platform/icd_test_log.h>
-#include "param_struct.h"
+#include <stdio.h>
 
 extern int test_create_calls();
 extern int test_platforms();
@@ -38,8 +38,7 @@ int main(int argc, char **argv)
     if (test_icd_match()) {
         printf("ICD Loader Test FAILED\n");
         return 1;
-    } else {
-        printf("ICD Loader Test PASSED\n");
-        return 0;
     }
+    printf("ICD Loader Test PASSED\n");
+    return 0;
 }

--- a/test/loader_test/test_buffer_object.c
+++ b/test/loader_test/test_buffer_object.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_mem buffer;

--- a/test/loader_test/test_cl_runtime.c
+++ b/test/loader_test/test_cl_runtime.c
@@ -1,5 +1,5 @@
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_command_queue command_queue;

--- a/test/loader_test/test_clgl.c
+++ b/test/loader_test/test_clgl.c
@@ -1,10 +1,10 @@
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 
+#include "param_struct.h"
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
 #include <CL/cl_gl_ext.h>
-#include "param_struct.h"
 #include <platform/icd_test_log.h>
 
 extern cl_context context;
@@ -310,38 +310,49 @@ int test_OpenGL_share()
 {
 	int i;
     
-    for(i=0;i<NUM_ITEMS_clCreateFromGLBuffer;i++)
+    for(i=0;i<NUM_ITEMS_clCreateFromGLBuffer;i++) {
 		test_clCreateFromGLBuffer(&clCreateFromGLBufferData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clCreateFromGLTexture;i++)
+    for(i=0;i<NUM_ITEMS_clCreateFromGLTexture;i++) {
 		test_clCreateFromGLTexture(&clCreateFromGLTextureData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clCreateFromGLTexture2D;i++)
+    for(i=0;i<NUM_ITEMS_clCreateFromGLTexture2D;i++) {
 		test_clCreateFromGLTexture2D(&clCreateFromGLTexture2DData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clCreateFromGLTexture3D;i++)
+    for(i=0;i<NUM_ITEMS_clCreateFromGLTexture3D;i++) {
 		test_clCreateFromGLTexture3D(&clCreateFromGLTexture3DData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clCreateFromGLRenderbuffer;i++)
+    for(i=0;i<NUM_ITEMS_clCreateFromGLRenderbuffer;i++) {
 		test_clCreateFromGLRenderbuffer(&clCreateFromGLRenderbufferData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clGetGLObjectInfo;i++)
+    for(i=0;i<NUM_ITEMS_clGetGLObjectInfo;i++) {
 		test_clGetGLObjectInfo(&clGetGLObjectInfoData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clGetGLTextureInfo;i++)
+    for(i=0;i<NUM_ITEMS_clGetGLTextureInfo;i++) {
 		test_clGetGLTextureInfo(&clGetGLTextureInfoData[i]);
+    }
 
-    for(i=0;i<NUM_ITEMS_clEnqueueAcquireGLObjects;i++)
+    for(i=0;i<NUM_ITEMS_clEnqueueAcquireGLObjects;i++) {
 		test_clEnqueueAcquireGLObjects(&clEnqueueAcquireGLObjectsData[i]);
+    }
         
-    for(i=0;i<NUM_ITEMS_clEnqueueReleaseGLObjects;i++)
+    for(i=0;i<NUM_ITEMS_clEnqueueReleaseGLObjects;i++) {
 		test_clEnqueueReleaseGLObjects(&clEnqueueReleaseGLObjectsData[i]);	
+    }
     
-    for(i=0;i<NUM_ITEMS_clCreateEventFromGLsyncKHR;i++)
+    for(i=0;i<NUM_ITEMS_clCreateEventFromGLsyncKHR;i++) {
 		test_clCreateEventFromGLsyncKHR(&clCreateEventFromGLsyncKHRData[i]);
+    }
     
-    for(i=0;i<NUM_ITEMS_clGetGLContextInfoKHR;i++)
+    for(i=0;i<NUM_ITEMS_clGetGLContextInfoKHR;i++) {
 		test_clGetGLContextInfoKHR(&clGetGLContextInfoKHRData[i]);
+    }
     
     return 0;
 }

--- a/test/loader_test/test_create_calls.c
+++ b/test/loader_test/test_create_calls.c
@@ -1,12 +1,12 @@
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern void CL_CALLBACK createcontext_callback(const char* a, const void* b, size_t c, void* d);
@@ -568,7 +568,7 @@ int test_clReleaseSampler(const struct clReleaseSampler_st *data)
 
 int test_clReleaseMemObject(const struct clReleaseMemObject_st *data)
 {
-    int ret_val = -15;
+    int ret_val = CL_OUT_OF_RESOURCES;
     test_icd_app_log("clReleaseMemObject(%p)\n", data->memobj);
 
     ret_val = clReleaseMemObject(data->memobj);

--- a/test/loader_test/test_image_objects.c
+++ b/test/loader_test/test_image_objects.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_mem image;

--- a/test/loader_test/test_kernel.c
+++ b/test/loader_test/test_kernel.c
@@ -6,8 +6,8 @@
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #endif
 
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_kernel kernel;

--- a/test/loader_test/test_platforms.c
+++ b/test/loader_test/test_platforms.c
@@ -1,5 +1,5 @@
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_context context;

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -1,5 +1,5 @@
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_context context;

--- a/test/loader_test/test_sampler_objects.c
+++ b/test/loader_test/test_sampler_objects.c
@@ -1,5 +1,5 @@
-#include <CL/cl.h>
 #include "param_struct.h"
+#include <CL/cl.h>
 #include <platform/icd_test_log.h>
 
 extern cl_sampler  sampler;

--- a/test/log/icd_test_log.c
+++ b/test/log/icd_test_log.c
@@ -1,9 +1,9 @@
-#include<sys/stat.h>
-#include<stdlib.h>
-#include<stdio.h>
-#include<stdarg.h>
-#include<CL/cl.h>
-#include<platform/icd_test_log.h>
+#include <CL/cl.h>
+#include <platform/icd_test_log.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
 
 #define APP_LOG_FILE  "icd_test_app_log.txt"
 #define STUB_LOG_FILE "icd_test_stub_log.txt"
@@ -31,7 +31,7 @@ void test_icd_app_log(const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    vfprintf(app_log_file, format, args);
+    vfprintf(app_log_file, format, args); // NOLINT
     va_end(args);
 }
 
@@ -56,7 +56,7 @@ void test_icd_stub_log(const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    vfprintf(stub_log_file, format, args);
+    vfprintf(stub_log_file, format, args); // NOLINT
     va_end(args);
 }
 


### PR DESCRIPTION
* Add initial .clang-tidy config
* Clear code base of found lints

It does not fully resolve #68 since we still need to enable a higher warning level in the compiler itself.

I've enabled all checks in clang-tidy and marked a few ones that I encountered while fixing the code as errors. `misc-unused-parameters` breaks on C, that's why I disabled it. We can change the concrete list of checks later on and tweak some parameters, but this PR cleans the code of all things found so far by clang-tidy.

The `malloc` of wrong size in one of the tests was a really good catch.

That's probably as good as we can get without converting the project to C++ (which, I mean, why not...)