### PR TITLE
Add a path separator to OCL_ICD_VENDORS

### DIFF
--- a/loader/icd_platform.h
+++ b/loader/icd_platform.h
@@ -24,9 +24,9 @@
 #define PATH_SEPARATOR  ':'
 #define DIRECTORY_SYMBOL '/'
 #ifdef __ANDROID__
-#define ICD_VENDOR_PATH "/system/vendor/Khronos/OpenCL/vendors/";
+#define ICD_VENDOR_PATH "/system/vendor/Khronos/OpenCL/vendors";
 #else
-#define ICD_VENDOR_PATH "/etc/OpenCL/vendors/";
+#define ICD_VENDOR_PATH "/etc/OpenCL/vendors";
 #endif // ANDROID
 
 #elif defined(_WIN32)

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -84,13 +84,13 @@ void khrIcdOsVendorsEnumerate(void)
                     }
 
                     // allocate space for the full path of the vendor library name
-                    fileName = malloc(strlen(dirEntry->d_name) + strlen(vendorPath) + 1);
+                    fileName = malloc(strlen(dirEntry->d_name) + strlen(vendorPath) + 2);
                     if (!fileName)
                     {
                         KHR_ICD_TRACE("Failed allocate space for ICD file path\n");
                         break;
                     }
-                    sprintf(fileName, "%s%s", vendorPath, dirEntry->d_name);
+                    sprintf(fileName, "%s/%s", vendorPath, dirEntry->d_name);
 
                     // open the file and read its contents
                     fin = fopen(fileName, "r");


### PR DESCRIPTION
When using the `OCL_ICD_VENDORS` environment variable a trailing `/`
path separator must be provided by the user, this is surprising.

This patch updates the `sprintf` call to include a `/` when constructing
the `.icd` file path. It also removes the trailing `/` from instances of
the `ICD_VENDOR_PATH` to canonicalised path strings. Existing scripts
which specify a trailing `/` when setting `OCL_ICD_VENDORS` will
continue working as expected since duplicate path separators `//`, while
not canonical, work as if a single path separator is specified.