### PR TITLE
Update and modernize some aspects of CMake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,6 @@ before_build:
   - cmake -DOPENCL_ICD_LOADER_HEADERS_DIR=inc/OpenCL-Headers -H. -Bbuild -A%PLATFORM%
 
 build:
-  project: build\OPENCL_ICD_LOADER.sln
+  project: build\OpenCL-ICD-Loader.sln
   parallel: true
   verbosity: normal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.1)
 
-project (OPENCL_ICD_LOADER)
+project (OpenCL-ICD-Loader VERSION 1.2)
 include (GNUInstallDirs)
 find_package (Threads REQUIRED)
 
@@ -76,6 +76,7 @@ set (OPENCL_ICD_LOADER_HEADERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/inc CACHE PATH "P
 
 add_library (OpenCL ${OPENCL_ICD_LOADER_SOURCES})
 set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
+target_include_directories(OpenCL SYSTEM PUBLIC ${OPENCL_ICD_LOADER_HEADERS_DIR})
 
 if (WIN32)
     target_link_libraries (OpenCL cfgmgr32.lib)


### PR DESCRIPTION
Ease integration with projects targeting more recent CMake versions:

* Update minimum required CMake version to 3.1.
* Specify a version `1.2` to the `project` CMake command, this silences
  developer warnings when the OpenCL-ICD-Loader is integrated in another
  project using `add_subdirectory`.
* Specify include directory on the `OpenCL` target, this removes the
  need to set the OpenCL-Headers include directory globally (old CMake)
  or set them manually per target which links the `OpenCL` target
  library.