### PR TITLE
Fix build of tests with -fno-common

### DIFF
--- a/test/loader_test/test_cl_runtime.c
+++ b/test/loader_test/test_cl_runtime.c
@@ -4,7 +4,7 @@
 
 extern cl_command_queue command_queue;
 
-cl_int ret_val;
+static cl_int ret_val;
 
 const struct clRetainCommandQueue_st clRetainCommandQueueData[NUM_ITEMS_clRetainCommandQueue] = {
 	{NULL}

--- a/test/loader_test/test_clgl.c
+++ b/test/loader_test/test_clgl.c
@@ -12,7 +12,7 @@ extern cl_mem buffer;
 extern cl_command_queue command_queue;
 extern cl_event event;
 extern cl_context_properties context_properties[3];
-cl_int ret_val;
+static cl_int ret_val;
 cl_mem ret_mem;
 
 struct clCreateFromGLBuffer_st clCreateFromGLBufferData[NUM_ITEMS_clCreateFromGLBuffer] = {

--- a/test/loader_test/test_image_objects.c
+++ b/test/loader_test/test_image_objects.c
@@ -10,7 +10,7 @@ extern cl_command_queue command_queue;
 extern cl_event event;
 extern cl_mem buffer;
 
-int ret_val;
+static int ret_val;
 
 const struct clGetSupportedImageFormats_st clGetSupportedImageFormatsData[NUM_ITEMS_clGetSupportedImageFormats] =
 {

--- a/test/loader_test/test_kernel.c
+++ b/test/loader_test/test_kernel.c
@@ -15,7 +15,7 @@ extern cl_event event;
 extern cl_context  context;
 extern cl_command_queue command_queue;
 extern cl_device_id devices;
-int ret_val;
+static int ret_val;
 extern void CL_CALLBACK setevent_callback(cl_event _a, cl_int _b, void* _c);
 extern void CL_CALLBACK setprintf_callback(cl_context _a, cl_uint _b, char* _c, void* _d );
 

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -7,7 +7,7 @@ extern cl_program program;
 extern cl_platform_id platform;
 extern cl_device_id devices;
 
-int ret_val;
+static int ret_val;
 
 extern void CL_CALLBACK program_callback(cl_program _a, void* _b);
 

--- a/test/loader_test/test_sampler_objects.c
+++ b/test/loader_test/test_sampler_objects.c
@@ -3,7 +3,7 @@
 #include <platform/icd_test_log.h>
 
 extern cl_sampler  sampler;
-int ret_val;
+static int ret_val;
 
 const struct clRetainSampler_st clRetainSamplerData[NUM_ITEMS_clRetainSampler]=
 {


### PR DESCRIPTION
Starting from gcc-10 and clang-11, "-fcommon" is switched to
"-fno-common" by default. This changed code generator to emit
globals without explicit initializer from .bss (via COMMON symbol type)
to .data (via DEFAULT symbol type), which leads to mutltiple definitions
error:

```
CMakeFiles/icd_loader_test.dir/test_platforms.c.o:(.bss+0x0): multipledefinition of `ret_val'
CMakeFiles/icd_loader_test.dir/test_kernel.c.o:(.bss+0x0): first definedhere
CMakeFiles/icd_loader_test.dir/test_program_objects.c.o:(.bss+0x0):multiple definition of `ret_val'
CMakeFiles/icd_loader_test.dir/test_kernel.c.o:(.bss+0x0): first definedhere
CMakeFiles/icd_loader_test.dir/test_sampler_objects.c.o:(.bss+0x0):multiple definition of `ret_val'
CMakeFiles/icd_loader_test.dir/test_kernel.c.o:(.bss+0x0): first definedhere
CMakeFiles/icd_loader_test.dir/test_cl_runtime.c.o:(.bss+0x0): multipledefinition of `ret_val'
CMakeFiles/icd_loader_test.dir/test_kernel.c.o:(.bss+0x0): first definedhere
CMakeFiles/icd_loader_test.dir/test_clgl.c.o:(.bss+0x0): multipledefinition of `ret_val'
CMakeFiles/icd_loader_test.dir/test_kernel.c.o:(.bss+0x0): first definedhere
CMakeFiles/icd_loader_test.dir/test_image_objects.c.o:(.bss+0x0):multiple definition of `ret_val'
CMakeFiles/icd_loader_test.dir/test_kernel.c.o:(.bss+0x0): first definedhere
```

This patch added "static" storage class specifier to "ret_val"
variables, so they are not shared between different translation units.
To reproduce the error with older compiler, add "-fno-common" to compile
flags explicitly (-DCMAKE_C_FLAGS="-fno-common")

Signed-off-by: Alexey Sachkov <alexey.sachkov@intel.com>