### PR TITLE
Make ret_val and ret_mem local to the functions in which they are used.

### DIFF
--- a/test/loader_test/test_cl_runtime.c
+++ b/test/loader_test/test_cl_runtime.c
@@ -4,8 +4,6 @@
 
 extern cl_command_queue command_queue;
 
-cl_int ret_val;
-
 const struct clRetainCommandQueue_st clRetainCommandQueueData[NUM_ITEMS_clRetainCommandQueue] = {
 	{NULL}
 };
@@ -16,6 +14,8 @@ const struct clGetCommandQueueInfo_st clGetCommandQueueInfoData[NUM_ITEMS_clGetC
 
 int test_clRetainCommandQueue(const struct clRetainCommandQueue_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clRetainCommandQueue(%p)\n", command_queue);
 
     ret_val = clRetainCommandQueue(command_queue);
@@ -28,6 +28,8 @@ int test_clRetainCommandQueue(const struct clRetainCommandQueue_st *data)
 
 int test_clGetCommandQueueInfo(const struct clGetCommandQueueInfo_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetCommandQueueInfo(%p, %u, %u, %p, %p)\n",
                      command_queue,
                      data->param_name,
@@ -40,7 +42,7 @@ int test_clGetCommandQueueInfo(const struct clGetCommandQueueInfo_st *data)
                                     data->param_value_size,
                                     data->param_value,
                                     data->param_value_size_ret);
-    
+
     test_icd_app_log("Value returned: %d\n", ret_val);
 
     return 0;
@@ -54,7 +56,7 @@ int test_cl_runtime()
 	for (i=0; i<NUM_ITEMS_clRetainCommandQueue; i++)	{
 		test_clRetainCommandQueue(&clRetainCommandQueueData[i]);
 	}
-    
+
     for (i=0; i<NUM_ITEMS_clGetCommandQueueInfo; i++)    {
         test_clGetCommandQueueInfo(&clGetCommandQueueInfoData[i]);
     }

--- a/test/loader_test/test_clgl.c
+++ b/test/loader_test/test_clgl.c
@@ -12,8 +12,6 @@ extern cl_mem buffer;
 extern cl_command_queue command_queue;
 extern cl_event event;
 extern cl_context_properties context_properties[3];
-cl_int ret_val;
-cl_mem ret_mem;
 
 struct clCreateFromGLBuffer_st clCreateFromGLBufferData[NUM_ITEMS_clCreateFromGLBuffer] = {
 	{NULL, 0x0, 0, NULL}
@@ -21,20 +19,21 @@ struct clCreateFromGLBuffer_st clCreateFromGLBufferData[NUM_ITEMS_clCreateFromGL
 
 int test_clCreateFromGLBuffer(const struct clCreateFromGLBuffer_st* data)
 {
+    cl_mem ret_mem;
 
     test_icd_app_log("clCreateFromGLBuffer(%p, %x, %u, %p)\n",
                      context,
                      data->flags,
-                     data->bufobj, 
+                     data->bufobj,
                      data->errcode_ret);
 
     ret_mem = clCreateFromGLBuffer(context,
                                    data->flags,
-                                   data->bufobj, 
-                                   data->errcode_ret);	
+                                   data->bufobj,
+                                   data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", ret_mem);
-    
+
     return 0;
 }
 
@@ -44,23 +43,25 @@ struct clCreateFromGLTexture_st clCreateFromGLTextureData[NUM_ITEMS_clCreateFrom
 
 int test_clCreateFromGLTexture(const struct clCreateFromGLTexture_st* data)
 {
+    cl_mem ret_mem;
+
     test_icd_app_log("clCreateFromGLTexture(%p, %x, %d, %d, %u, %p)\n",
                      context,
-                     data->flags, 
+                     data->flags,
                      data->texture_target,
-                     data->miplevel, 
-                     data->texture, 
+                     data->miplevel,
+                     data->texture,
                      data->errcode_ret);
 
     ret_mem = clCreateFromGLTexture(context,
-                                    data->flags, 
+                                    data->flags,
                                     data->texture_target,
-                                    data->miplevel, 
-                                    data->texture, 
+                                    data->miplevel,
+                                    data->texture,
                                     data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", ret_mem);
-    
+
     return 0;
 }
 
@@ -70,23 +71,25 @@ struct clCreateFromGLTexture2D_st clCreateFromGLTexture2DData[NUM_ITEMS_clCreate
 
 int test_clCreateFromGLTexture2D(const struct clCreateFromGLTexture2D_st* data)
 {
+    cl_mem ret_mem;
+
     test_icd_app_log("clCreateFromGLTexture2D(%p, %x, %d, %d, %u, %p)\n",
                      context,
-                     data->flags, 
+                     data->flags,
                      data->texture_target,
-                     data->miplevel, 
-                     data->texture, 
+                     data->miplevel,
+                     data->texture,
                      data->errcode_ret);
 
     ret_mem = clCreateFromGLTexture2D(context,
-                                      data->flags, 
+                                      data->flags,
                                       data->texture_target,
-                                      data->miplevel, 
-                                      data->texture, 
+                                      data->miplevel,
+                                      data->texture,
                                       data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", ret_mem);
-    
+
     return 0;
 }
 
@@ -95,21 +98,23 @@ struct clCreateFromGLTexture3D_st clCreateFromGLTexture3DData[NUM_ITEMS_clCreate
 };
 
 int test_clCreateFromGLTexture3D(const struct clCreateFromGLTexture3D_st* data)
-{	
+{
+    cl_mem ret_mem;
+
     test_icd_app_log("clCreateFromGLTexture3D(%p, %x, %d, %d, %u, %p)\n",
                      context,
                      data->flags,
                      data->texture_target,
-                     data->miplevel, 
-                     data->texture, 
+                     data->miplevel,
+                     data->texture,
                      data->errcode_ret);
 
     ret_mem = clCreateFromGLTexture3D(context,
-                                      data->flags, 
+                                      data->flags,
                                       data->texture_target,
-                                      data->miplevel, 
-                                      data->texture, 
-                                      data->errcode_ret);	
+                                      data->miplevel,
+                                      data->texture,
+                                      data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", ret_mem);
 
@@ -122,15 +127,17 @@ struct clCreateFromGLRenderbuffer_st clCreateFromGLRenderbufferData[NUM_ITEMS_cl
 
 int test_clCreateFromGLRenderbuffer(const struct clCreateFromGLRenderbuffer_st* data)
 {
+    cl_mem ret_mem;
+
     test_icd_app_log("clCreateFromGLRenderbuffer(%p, %x, %d, %p)\n",
-                     context, 
+                     context,
                      data->flags,
-                     data->renderbuffer, 
+                     data->renderbuffer,
                      data->errcode_ret);
 
-    ret_mem = clCreateFromGLRenderbuffer(context, 
+    ret_mem = clCreateFromGLRenderbuffer(context,
                                          data->flags,
-                                         data->renderbuffer, 
+                                         data->renderbuffer,
                                          data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", ret_mem);
@@ -144,17 +151,19 @@ struct clGetGLObjectInfo_st clGetGLObjectInfoData[NUM_ITEMS_clGetGLObjectInfo] =
 
 int test_clGetGLObjectInfo(const struct clGetGLObjectInfo_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetGLObjectInfo(%p, %p, %p)\n",
                      buffer,
-                     data->gl_object_type, 
+                     data->gl_object_type,
                      data->gl_object_name);
 
     ret_val = clGetGLObjectInfo(buffer,
-                                data->gl_object_type, 
+                                data->gl_object_type,
                                 data->gl_object_name);
 
     test_icd_app_log("Value returned: %p\n", ret_val);
-    
+
     return ret_val;
 
 }
@@ -165,16 +174,18 @@ struct clGetGLTextureInfo_st clGetGLTextureInfoData[NUM_ITEMS_clGetGLTextureInfo
 
 int test_clGetGLTextureInfo(const struct clGetGLTextureInfo_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetGLTextureInfo(%p, %u, %u, %p, %p)\n",
                      buffer,
                      data->param_name,
-                     data->param_value_size, 
+                     data->param_value_size,
                      data->param_value,
                      data->param_value_size_ret);
 
     ret_val = clGetGLTextureInfo (buffer,
                                   data->param_name,
-                                  data->param_value_size, 
+                                  data->param_value_size,
                                   data->param_value,
                                   data->param_value_size_ret);
 
@@ -189,19 +200,21 @@ struct clEnqueueAcquireGLObjects_st clEnqueueAcquireGLObjectsData[NUM_ITEMS_clEn
 
 int test_clEnqueueAcquireGLObjects(const struct clEnqueueAcquireGLObjects_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueAcquireGLObjects(%p, %u, %p, %u, %p, %p)\n",
                      command_queue,
-                     data->num_objects, 
+                     data->num_objects,
                      data->mem_objects,
                      data->num_events_in_wait_list,
                      &event,
                      &event);
 
     ret_val = clEnqueueAcquireGLObjects (command_queue,
-                                         data->num_objects, 
+                                         data->num_objects,
                                          data->mem_objects,
                                          data->num_events_in_wait_list,
-                                         &event, 
+                                         &event,
                                          &event);
 
     test_icd_app_log("Value returned: %p\n", ret_val);
@@ -215,19 +228,21 @@ struct clEnqueueReleaseGLObjects_st clEnqueueReleaseGLObjectsData[NUM_ITEMS_clEn
 
 int test_clEnqueueReleaseGLObjects(const struct clEnqueueReleaseGLObjects_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueReleaseGLObjects(%p, %u, %p, %u, %p, %p)\n",
                      command_queue,
-                     data->num_objects, 
+                     data->num_objects,
                      data->mem_objects,
                      data->num_events_in_wait_list,
-                     &event, 
+                     &event,
                      &event);
 
     ret_val = clEnqueueReleaseGLObjects (command_queue,
-                                         data->num_objects, 
+                                         data->num_objects,
                                          data->mem_objects,
                                          data->num_events_in_wait_list,
-                                         &event, 
+                                         &event,
                                          &event);
 
 
@@ -250,8 +265,8 @@ int test_clCreateEventFromGLsyncKHR(const struct clCreateEventFromGLsyncKHR_st* 
     PFN_clCreateEventFromGLsyncKHR pfn_clCreateEventFromGLsyncKHR = NULL;
 
     test_icd_app_log("clCreateEventFromGLsyncKHR(%p, %p, %p)\n",
-                     context, 
-                     data->sync, 
+                     context,
+                     data->sync,
                      data->errcode_ret);
 
     pfn_clCreateEventFromGLsyncKHR = clGetExtensionFunctionAddress("clCreateEventFromGLsyncKHR");
@@ -260,8 +275,8 @@ int test_clCreateEventFromGLsyncKHR(const struct clCreateEventFromGLsyncKHR_st* 
         return 1;
     }
 
-    ret_event = pfn_clCreateEventFromGLsyncKHR (context, 
-                                            data->sync, 
+    ret_event = pfn_clCreateEventFromGLsyncKHR (context,
+                                            data->sync,
                                             data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", ret_event);
@@ -278,14 +293,16 @@ typedef CL_API_ENTRY cl_int
                                          size_t                        /* param_value_size */,
                                          void *                        /* param_value */,
                                          size_t *                      /* param_value_size_ret */);
- 
+
 int test_clGetGLContextInfoKHR(const struct clGetGLContextInfoKHR_st* data)
 {
+    cl_int ret_val;
+
     PFN_clGetGLContextInfoKHR pfn_clGetGLContextInfoKHR = NULL;
     test_icd_app_log("clGetGLContextInfoKHR(%p, %u, %u, %p, %p)\n",
                      context_properties,
                      data->param_name,
-                     data->param_value_size, 
+                     data->param_value_size,
                      data->param_value,
                      data->param_value_size_ret);
 
@@ -297,7 +314,7 @@ int test_clGetGLContextInfoKHR(const struct clGetGLContextInfoKHR_st* data)
 
     ret_val = pfn_clGetGLContextInfoKHR(context_properties,
                                     data->param_name,
-                                    data->param_value_size, 
+                                    data->param_value_size,
                                     data->param_value,
                                     data->param_value_size_ret);
 
@@ -309,7 +326,7 @@ int test_clGetGLContextInfoKHR(const struct clGetGLContextInfoKHR_st* data)
 int test_OpenGL_share()
 {
 	int i;
-    
+
     for(i=0;i<NUM_ITEMS_clCreateFromGLBuffer;i++)
 		test_clCreateFromGLBuffer(&clCreateFromGLBufferData[i]);
 
@@ -333,15 +350,15 @@ int test_OpenGL_share()
 
     for(i=0;i<NUM_ITEMS_clEnqueueAcquireGLObjects;i++)
 		test_clEnqueueAcquireGLObjects(&clEnqueueAcquireGLObjectsData[i]);
-        
+
     for(i=0;i<NUM_ITEMS_clEnqueueReleaseGLObjects;i++)
-		test_clEnqueueReleaseGLObjects(&clEnqueueReleaseGLObjectsData[i]);	
-    
+		test_clEnqueueReleaseGLObjects(&clEnqueueReleaseGLObjectsData[i]);
+
     for(i=0;i<NUM_ITEMS_clCreateEventFromGLsyncKHR;i++)
 		test_clCreateEventFromGLsyncKHR(&clCreateEventFromGLsyncKHRData[i]);
-    
+
     for(i=0;i<NUM_ITEMS_clGetGLContextInfoKHR;i++)
 		test_clGetGLContextInfoKHR(&clGetGLContextInfoKHRData[i]);
-    
+
     return 0;
 }

--- a/test/loader_test/test_image_objects.c
+++ b/test/loader_test/test_image_objects.c
@@ -10,8 +10,6 @@ extern cl_command_queue command_queue;
 extern cl_event event;
 extern cl_mem buffer;
 
-int ret_val;
-
 const struct clGetSupportedImageFormats_st clGetSupportedImageFormatsData[NUM_ITEMS_clGetSupportedImageFormats] =
 {
     { NULL, 0x0, 0, 0, NULL, NULL }
@@ -59,6 +57,8 @@ const struct clGetImageInfo_st clGetImageInfoData[NUM_ITEMS_clGetImageInfo] =
 
 int test_clGetSupportedImageFormats(const struct clGetSupportedImageFormats_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetSupportedImageFormats(%p, %x, %u, %u, %p, %p)\n",
                      context,
                      data->flags,
@@ -66,7 +66,7 @@ int test_clGetSupportedImageFormats(const struct clGetSupportedImageFormats_st *
                      data->num_entries,
                      data->image_formats,
                      data->num_image_formats);
-    
+
     ret_val = clGetSupportedImageFormats(context,
                                     data->flags,
                                     data->image_type,
@@ -82,6 +82,8 @@ int test_clGetSupportedImageFormats(const struct clGetSupportedImageFormats_st *
 
 int test_clEnqueueCopyImageToBuffer(const struct clEnqueueCopyImageToBuffer_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueCopyImageToBuffer(%p, %p, %p, %p, %p, %u, %u, %p, %p)\n",
                      command_queue,
                      image,
@@ -111,6 +113,8 @@ int test_clEnqueueCopyImageToBuffer(const struct clEnqueueCopyImageToBuffer_st *
 
 int test_clEnqueueCopyBufferToImage(const struct clEnqueueCopyBufferToImage_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueCopyBufferToImage(%p, %p, %p, %u, %p, %p, %u, %p, %p)\n",
                      command_queue,
                      buffer,
@@ -178,11 +182,13 @@ int test_clEnqueueMapImage(const struct clEnqueueMapImage_st *data)
 
 int test_clEnqueueReadImage(const struct clEnqueueReadImage_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueReadImage(%p, %p, %u, %p, %p, %u, %u, %p, %u, %p, %p)\n",
                      command_queue,
                      image,
                      data->blocking_read,
-                     data->origin,            
+                     data->origin,
                      data->region,
                      data->row_pitch,
                      data->slice_pitch,
@@ -195,11 +201,11 @@ int test_clEnqueueReadImage(const struct clEnqueueReadImage_st *data)
                             image,
                             data->blocking_read,
                             data->origin,
-                            data->region, 
-                            data->row_pitch,  
-                            data->slice_pitch, 
-                            data->ptr,       
-                            data->num_events_in_wait_list,  
+                            data->region,
+                            data->row_pitch,
+                            data->slice_pitch,
+                            data->ptr,
+                            data->num_events_in_wait_list,
                             data->event_wait_list,
                             &event);
 
@@ -211,6 +217,8 @@ int test_clEnqueueReadImage(const struct clEnqueueReadImage_st *data)
 
 int test_clEnqueueWriteImage(const struct clEnqueueWriteImage_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueWriteImage(%p, %p, %u, %p, %p, %u, %u, %p, %u, %p, %p)\n",
                      command_queue,
                      image,
@@ -244,6 +252,8 @@ int test_clEnqueueWriteImage(const struct clEnqueueWriteImage_st *data)
 
 int test_clEnqueueFillImage(const struct clEnqueueFillImage_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueFillImage(%p, %p, %p, %p, %p, %u, %p, %p)\n",
                      command_queue,
                      image,
@@ -251,16 +261,16 @@ int test_clEnqueueFillImage(const struct clEnqueueFillImage_st *data)
                      data->origin,
                      data->region,
                      data->num_events_in_wait_list,
-                     data->event_wait_list, 
+                     data->event_wait_list,
                      &event);
 
     ret_val = clEnqueueFillImage(command_queue,
-                            image,    
+                            image,
                             data->fill_color,
                             data->origin,
                             data->region,
                             data->num_events_in_wait_list,
-                            data->event_wait_list, 
+                            data->event_wait_list,
                             &event);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
@@ -270,6 +280,8 @@ int test_clEnqueueFillImage(const struct clEnqueueFillImage_st *data)
 }
 int test_clEnqueueCopyImage(const struct clEnqueueCopyImage_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clEnqueueCopyImage(%p, %p, %p, %p, %p, %p, %u, %p, %p)\n",
                      command_queue,
                      image,
@@ -278,7 +290,7 @@ int test_clEnqueueCopyImage(const struct clEnqueueCopyImage_st *data)
                      data->dst_origin,
                      data->region,
                      data->num_events_in_wait_list,
-                     data->event_wait_list, 
+                     data->event_wait_list,
                      &event);
 
     ret_val = clEnqueueCopyImage(command_queue,
@@ -288,7 +300,7 @@ int test_clEnqueueCopyImage(const struct clEnqueueCopyImage_st *data)
                             data->dst_origin,
                             data->region,
                             data->num_events_in_wait_list,
-                            data->event_wait_list, 
+                            data->event_wait_list,
                             &event);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
@@ -300,6 +312,8 @@ int test_clEnqueueCopyImage(const struct clEnqueueCopyImage_st *data)
 
 int test_clGetImageInfo(const struct clGetImageInfo_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetImageInfo(%p, %u, %u, %p, %p)\n",
                      image,
                      data->param_name,

--- a/test/loader_test/test_platforms.c
+++ b/test/loader_test/test_platforms.c
@@ -8,8 +8,6 @@ extern cl_platform_id  platform;
 
 extern cl_device_id devices;
 
-int ret_val;
-
 struct clRetainContext_st clRetainContextData[NUM_ITEMS_clRetainContext] =
 {
     {NULL}
@@ -45,7 +43,9 @@ struct clRetainDevice_st clRetainDeviceData[NUM_ITEMS_clRetainDevice] =
 
 int test_clRetainContext(const struct clRetainContext_st* data)
 {
-    test_icd_app_log("clRetainContext(%p)\n", context); 
+    cl_int ret_val;
+
+    test_icd_app_log("clRetainContext(%p)\n", context);
 
     ret_val = clRetainContext(context);
 
@@ -58,18 +58,20 @@ int test_clRetainContext(const struct clRetainContext_st* data)
 
 int test_clGetContextInfo(const struct clGetContextInfo_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetContextInfo(%p, %u, %u, %p, %p)\n",
                      context,
-                     data->param_name, 
+                     data->param_name,
                      data->param_value_size,
-                     data->param_value, 
-                     data->param_value_size_ret); 
+                     data->param_value,
+                     data->param_value_size_ret);
 
 
     ret_val = clGetContextInfo(context,
-            data->param_name, 
+            data->param_name,
             data->param_value_size,
-            data->param_value, 
+            data->param_value,
             data->param_value_size_ret);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
@@ -79,18 +81,20 @@ int test_clGetContextInfo(const struct clGetContextInfo_st* data)
 
 int test_clGetPlatformInfo(const struct clGetPlatformInfo_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetPlatformInfo(%p, %u, %u, %p, %p)\n",
                      platform,
                      data->param_name,
                      data->param_value_size,
-                     data->param_value, 
-                     data->param_value_size_ret); 					 
+                     data->param_value,
+                     data->param_value_size_ret);
 
     ret_val = clGetPlatformInfo(platform,
             data->param_name,
             data->param_value_size,
             data->param_value,
-            data->param_value_size_ret); 
+            data->param_value_size_ret);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
 
@@ -99,19 +103,21 @@ int test_clGetPlatformInfo(const struct clGetPlatformInfo_st* data)
 }
 
 int test_clGetDeviceInfo(const struct clGetDeviceInfo_st* data)
-{ 
+{
+    cl_int ret_val;
+
     test_icd_app_log("clGetDeviceInfo(%p, %u, %u, %p, %p)\n",
                      devices,
-                     data->param_name, 
-                     data->param_value_size, 
-                     data->param_value, 
-                     data->param_value_size_ret);		 
+                     data->param_name,
+                     data->param_value_size,
+                     data->param_value,
+                     data->param_value_size_ret);
 
     ret_val = clGetDeviceInfo(devices,
-            data->param_name, 
-            data->param_value_size, 
-            data->param_value, 
-            data->param_value_size_ret);		 
+            data->param_name,
+            data->param_value_size,
+            data->param_value,
+            data->param_value_size_ret);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
 
@@ -120,18 +126,20 @@ int test_clGetDeviceInfo(const struct clGetDeviceInfo_st* data)
 
 int test_clCreateSubDevices(const struct clCreateSubDevices_st* data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clCreateSubDevices(%p, %p, %u, %p, %p)\n",
                      devices,
-                     data->properties, 
-                     data->num_entries, 
-                     &devices, 
-                     data->num_devices); 
+                     data->properties,
+                     data->num_entries,
+                     &devices,
+                     data->num_devices);
 
     ret_val = clCreateSubDevices(devices,
-            data->properties, 
+            data->properties,
             data->num_entries,
-            &devices, 
-            data->num_devices); 
+            &devices,
+            data->num_devices);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
 
@@ -140,9 +148,11 @@ int test_clCreateSubDevices(const struct clCreateSubDevices_st* data)
 
 int test_clRetainDevice(const struct clRetainDevice_st* data)
 {
-    test_icd_app_log("clRetainDevice(%p)\n", devices); 
+    cl_int ret_val;
 
-    ret_val = clRetainDevice(devices); 
+    test_icd_app_log("clRetainDevice(%p)\n", devices);
+
+    ret_val = clRetainDevice(devices);
 
     test_icd_app_log("Value returned: %d\n", ret_val);
 
@@ -153,31 +163,31 @@ int test_platforms()
 {
     int i;
 
-    for (i = 0;i<NUM_ITEMS_clRetainContext;i++) { 
-        test_clRetainContext(&clRetainContextData[i]); 
-    } 
+    for (i = 0;i<NUM_ITEMS_clRetainContext;i++) {
+        test_clRetainContext(&clRetainContextData[i]);
+    }
 
-    for (i = 0;i<NUM_ITEMS_clGetContextInfo;i++) { 
-        test_clGetContextInfo(&clGetContextInfoData[i]); 
-    } 
+    for (i = 0;i<NUM_ITEMS_clGetContextInfo;i++) {
+        test_clGetContextInfo(&clGetContextInfoData[i]);
+    }
 
 #if 0
-    for (i = 0;i<NUM_ITEMS_clGetPlatformInfo;i++) { 
-        test_clGetPlatformInfo(&clGetPlatformInfoData[i]); 
+    for (i = 0;i<NUM_ITEMS_clGetPlatformInfo;i++) {
+        test_clGetPlatformInfo(&clGetPlatformInfoData[i]);
     }
 #endif
 
-    for (i = 0;i<NUM_ITEMS_clGetDeviceInfo;i++) { 
-        test_clGetDeviceInfo(&clGetDeviceInfoData[i]); 
-    } 
+    for (i = 0;i<NUM_ITEMS_clGetDeviceInfo;i++) {
+        test_clGetDeviceInfo(&clGetDeviceInfoData[i]);
+    }
 
-    for (i = 0;i<NUM_ITEMS_clCreateSubDevices;i++) { 
-        test_clCreateSubDevices(&clCreateSubDevicesData[i]); 
-    } 
+    for (i = 0;i<NUM_ITEMS_clCreateSubDevices;i++) {
+        test_clCreateSubDevices(&clCreateSubDevicesData[i]);
+    }
 
-    for (i = 0;i<NUM_ITEMS_clRetainDevice;i++) { 
-        test_clRetainDevice(&clRetainDeviceData[i]); 
-    } 
+    for (i = 0;i<NUM_ITEMS_clRetainDevice;i++) {
+        test_clRetainDevice(&clRetainDeviceData[i]);
+    }
 
     return 0;
 }

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -7,8 +7,6 @@ extern cl_program program;
 extern cl_platform_id platform;
 extern cl_device_id devices;
 
-int ret_val;
-
 extern void CL_CALLBACK program_callback(cl_program _a, void* _b);
 
 const struct clRetainProgram_st clRetainProgramData[NUM_ITEMS_clRetainProgram]=
@@ -53,6 +51,8 @@ const struct clGetProgramBuildInfo_st clGetProgramBuildInfoData[NUM_ITEMS_clGetP
 
 int test_clRetainProgram(const struct clRetainProgram_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clRetainProgram(%p)\n",
                     program);
 
@@ -67,6 +67,8 @@ int test_clRetainProgram(const struct clRetainProgram_st *data)
 
 int test_clBuildProgram(const struct clBuildProgram_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clBuildProgram(%p, %u, %p, %p, %p, %p)\n",
                      program,
                      data->num_devices,
@@ -90,6 +92,8 @@ int test_clBuildProgram(const struct clBuildProgram_st *data)
 
 int test_clCompileProgram(const struct clCompileProgram_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clCompileProgram(%p, %u, %p, %p, %u, %p, %p, %p)\n",
                      program,
                      data->num_devices,
@@ -148,6 +152,8 @@ int test_clLinkProgram(const struct clLinkProgram_st *data)
 
 int test_clUnloadPlatformCompiler(const struct clUnloadPlatformCompiler_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clUnloadPlatformCompiler(%p)\n", platform);
 
     ret_val=clUnloadPlatformCompiler(platform);
@@ -162,7 +168,7 @@ int test_clGetExtensionFunctionAddressForPlatform(const struct clGetExtensionFun
 {
     void *return_value;
     test_icd_app_log("clGetExtensionFunctionAddressForPlatform(%p, %p)\n",
-                     platform,  
+                     platform,
                      data->func_name);
 
     return_value=clGetExtensionFunctionAddressForPlatform(platform,
@@ -176,6 +182,8 @@ int test_clGetExtensionFunctionAddressForPlatform(const struct clGetExtensionFun
 
 int test_clGetProgramInfo(const struct clGetProgramInfo_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetProgramInfo(%p, %u, %u, %p, %p)\n",
                      program,
                      data->param_name,
@@ -197,6 +205,8 @@ int test_clGetProgramInfo(const struct clGetProgramInfo_st *data)
 
 int test_clGetProgramBuildInfo(const struct clGetProgramBuildInfo_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetProgramBuildInfo(%p, %p, %u, %u, %p, %p)\n",
                      program,
                      data->device,
@@ -224,7 +234,7 @@ int test_program_objects()
 
     for (i=0;i<NUM_ITEMS_clRetainProgram;i++)   {
         test_clRetainProgram(&clRetainProgramData[i]);
-    }    
+    }
 
     for (i=0;i<NUM_ITEMS_clBuildProgram;i++)    {
         test_clBuildProgram(&clBuildProgramData[i]);

--- a/test/loader_test/test_sampler_objects.c
+++ b/test/loader_test/test_sampler_objects.c
@@ -3,7 +3,6 @@
 #include <platform/icd_test_log.h>
 
 extern cl_sampler  sampler;
-int ret_val;
 
 const struct clRetainSampler_st clRetainSamplerData[NUM_ITEMS_clRetainSampler]=
 {
@@ -18,6 +17,8 @@ const struct clGetSamplerInfo_st clGetSamplerInfoData[NUM_ITEMS_clGetSamplerInfo
 
 int test_clRetainSampler(const struct clRetainSampler_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clRetainSampler(%p)\n", sampler);
 
     ret_val=clRetainSampler(sampler);
@@ -29,6 +30,8 @@ int test_clRetainSampler(const struct clRetainSampler_st *data)
 
 int test_clGetSamplerInfo(const struct clGetSamplerInfo_st *data)
 {
+    cl_int ret_val;
+
     test_icd_app_log("clGetSamplerInfo(%p, %u, %u, %p, %p)\n",
                      sampler,
                      data->param_name,


### PR DESCRIPTION
Make ret_val and ret_mem local to the functions in which they are used.
Also consistently used cl_int and cl_mem