### PR TITLE
remove WDK dependency for OpenCL ICD loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set (OPENCL_ICD_LOADER_SOURCES
 
 if (WIN32)
     list (APPEND OPENCL_ICD_LOADER_SOURCES 
+        loader/windows/adapter.h
         loader/windows/icd_windows.c
         loader/windows/icd_windows.h
         loader/windows/icd_windows_dxgk.c
@@ -81,28 +82,6 @@ set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
 
 if (WIN32)
     target_link_libraries (OpenCL cfgmgr32.lib RuntimeObject.lib)
-
-    option (OPENCL_ICD_LOADER_REQUIRE_WDK "Build with D3DKMT support, which requires the Windows WDK." ON)
-    if (OPENCL_ICD_LOADER_REQUIRE_WDK)
-        if(DEFINED ENV{WDKContentRoot})
-            file(GLOB D3DKMT_HEADER "$ENV{WDKContentRoot}/Include/*/km/d3dkmthk.h")
-        else()
-            file(GLOB D3DKMT_HEADER "$ENV{HOMEDRIVE}/Program Files */Windows Kits/10/Include/*/km/d3dkmthk.h")
-        endif()
-
-        if(D3DKMT_HEADER)
-            list(GET D3DKMT_HEADER -1 LATEST_D3DKMT_HEADER)
-            get_filename_component(WDK_DIRECTORY ${LATEST_D3DKMT_HEADER} DIRECTORY)
-            get_filename_component(WDK_DIRECTORY ${WDK_DIRECTORY} DIRECTORY)
-            message(STATUS "Found the Windows WDK in: ${WDK_DIRECTORY}")
-            target_compile_definitions(OpenCL PRIVATE OPENCL_ICD_LOADER_REQUIRE_WDK)
-            target_include_directories(OpenCL PRIVATE ${WDK_DIRECTORY}/um)
-            target_include_directories(OpenCL PRIVATE ${WDK_DIRECTORY}/km)
-            target_include_directories(OpenCL PRIVATE ${WDK_DIRECTORY}/shared)
-        else()
-            message(FATAL_ERROR "The Windows WDK was not found. Consider disabling OPENCL_ICD_LOADER_REQUIRE_WDK. Aborting.")
-        endif()
-    endif()
 
     if(NOT USE_DYNAMIC_VCXX_RUNTIME)
         string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")

--- a/README.md
+++ b/README.md
@@ -30,15 +30,6 @@ The OpenCL ICD Loader requires OpenCL Headers.
 To use system OpenCL Headers, please specify the OpenCL Header location using the CMake variable `OPENCL_ICD_LOADER_HEADERS_DIR`.
 By default, the OpenCL ICD Loader will look for OpenCL Headers in the `inc` directory.
 
-By default, the OpenCL ICD Loader on Windows requires the Windows Driver Kit (WDK).
-To build OpenCL ICD Loader with WDK support -
-* Install recent Windows WDK currently at https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
-
-* Establish environment variable WDK to include directory. Ex: set WDK=C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0
-
-An OpenCL ICD Loader may be built without the Windows Driver Kit using the CMake variable `OPENCL_ICD_LOADER_REQUIRE_WDK`, however this option should be used with caution since it may prevent the OpenCL ICD Loader from enumerating some OpenCL implementations.
-This dependency may be removed in the future.
-
 The OpenCL ICD Loader uses CMake for its build system.
 If CMake is not provided by your build system or OS package manager, please consult the [CMake website](https://cmake.org).
 

--- a/loader/windows/OpenCL.rc
+++ b/loader/windows/OpenCL.rc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2020 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 #define OPENCL_ICD_LOADER_VERSION_MAJOR 2
 #define OPENCL_ICD_LOADER_VERSION_MINOR 2
-#define OPENCL_ICD_LOADER_VERSION_REV   7
+#define OPENCL_ICD_LOADER_VERSION_REV   8
 
 #ifdef RC_INVOKED
 
@@ -43,7 +43,7 @@ BEGIN
         BEGIN
             VALUE "FileDescription" ,"OpenCL Client DLL"
             VALUE "ProductName"     ,"Khronos OpenCL ICD Loader"
-            VALUE "LegalCopyright"  ,"Copyright \251 The Khronos Group Inc 2016-2019"
+            VALUE "LegalCopyright"  ,"Copyright \251 The Khronos Group Inc 2016-2020"
             VALUE "FileVersion"     ,OPENCL_ICD_LOADER_VERSION_STRING ".0"
             VALUE "CompanyName"     ,"Khronos Group"
             VALUE "InternalName"    ,"OpenCL"

--- a/loader/windows/adapter.h
+++ b/loader/windows/adapter.h
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2019 The Khronos Group Inc.
+* Copyright (c) 2019 Valve Corporation
+* Copyright (c) 2019 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Author: Lenny Komow <lenny@lunarg.com>
+*/
+
+typedef struct LoaderEnumAdapters2 {
+    ULONG adapter_count;
+    struct {
+        UINT handle;
+        LUID luid;
+        ULONG source_count;
+        BOOL present_move_regions_preferred;
+    } * adapters;
+} LoaderEnumAdapters2;
+
+typedef _Check_return_ NTSTATUS(APIENTRY *PFN_LoaderEnumAdapters2)(const LoaderEnumAdapters2 *);
+
+typedef enum AdapterInfoType {
+    LOADER_QUERY_TYPE_REGISTRY = 48,
+} AdapterInfoType;
+
+typedef struct LoaderQueryAdapterInfo {
+    UINT handle;
+    AdapterInfoType type;
+    VOID *private_data;
+    UINT private_data_size;
+} LoaderQueryAdapterInfo;
+
+typedef _Check_return_ NTSTATUS(APIENTRY *PFN_LoaderQueryAdapterInfo)(const LoaderQueryAdapterInfo *);
+
+typedef enum LoaderQueryRegistryType {
+    LOADER_QUERY_REGISTRY_ADAPTER_KEY = 1,
+} LoaderQueryRegistryType;
+
+typedef enum LoaderQueryRegistryStatus {
+    LOADER_QUERY_REGISTRY_STATUS_SUCCESS = 0,
+    LOADER_QUERY_REGISTRY_STATUS_BUFFER_OVERFLOW = 1,
+} LoaderQueryRegistryStatus;
+
+typedef struct LoaderQueryRegistryFlags {
+    union {
+        struct {
+            UINT translate_path : 1;
+            UINT mutable_value : 1;
+            UINT reserved : 30;
+        };
+        UINT value;
+    };
+} LoaderQueryRegistryFlags;
+
+typedef struct LoaderQueryRegistryInfo {
+    LoaderQueryRegistryType query_type;
+    LoaderQueryRegistryFlags query_flags;
+    WCHAR value_name[MAX_PATH];
+    ULONG value_type;
+    ULONG physical_adapter_index;
+    ULONG output_value_size;
+    LoaderQueryRegistryStatus status;
+    union {
+        DWORD output_dword;
+        UINT64 output_qword;
+        WCHAR output_string[1];
+        BYTE output_binary[1];
+    };
+} LoaderQueryRegistryInfo;


### PR DESCRIPTION
This is a similar change as #90, but it goes a bit farther and removes all WDK dependencies, including header file dependencies.  Instead of including a WDK header file, a private header file is used, which contains just the structure and function definitions needed by the OpenCL ICD loader.  This is the same mechanism used by the Vulkan loader, and indeed the private header file is copied unchanged from the Vulkan loader repo - see https://github.com/KhronosGroup/Vulkan-Loader/blob/master/loader/adapters.h.

I've intentionally kept the code flow fairly unchanged, and most of the diffs are due to slightly different structure member names in adapters.h.  At some point it would be beneficial to refactor this function slightly, I think, but that can be done as a follow-on PR.

The one change I did include in this PR is to use the "secure" version of `wcstombs`, so I believe this PR fixes #93.