### PR TITLE
add an option to disable support for OpenCLOn12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
 if (WIN32)
     target_link_libraries (OpenCL cfgmgr32.lib RuntimeObject.lib)
 
+    option (OPENCL_ICD_LOADER_DISABLE_OPENCLON12 "Disable support for OpenCLOn12. Support for OpenCLOn12 should only be disabled when building an import lib to link with, and must be enabled when building an ICD loader for distribution!" OFF)
+    if (OPENCL_ICD_LOADER_DISABLE_OPENCLON12)
+        target_compile_definitions(OpenCL PRIVATE OPENCL_ICD_LOADER_DISABLE_OPENCLON12)
+    endif()
+
     if(NOT USE_DYNAMIC_VCXX_RUNTIME)
         string(REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
         string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ add_library (OpenCL ${OPENCL_ICD_LOADER_SOURCES})
 set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
 
 if (WIN32)
-    target_link_libraries (OpenCL cfgmgr32.lib RuntimeObject.lib)
+    target_link_libraries (OpenCL cfgmgr32.lib runtimeobject.lib)
 
     option (OPENCL_ICD_LOADER_DISABLE_OPENCLON12 "Disable support for OpenCLOn12. Support for OpenCLOn12 should only be disabled when building an import lib to link with, and must be enabled when building an ICD loader for distribution!" OFF)
     if (OPENCL_ICD_LOADER_DISABLE_OPENCLON12)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ By default, the OpenCL ICD Loader will look for OpenCL Headers in the `inc` dire
 The OpenCL ICD Loader uses CMake for its build system.
 If CMake is not provided by your build system or OS package manager, please consult the [CMake website](https://cmake.org).
 
+The Windows OpenCL ICD Loader requires the Windows SDK to check for and enumerate the OpenCLOn12 ICD.
+An OpenCL ICD Loader can be built without a dependency on the Windows SDK using the CMake variable `OPENCL_ICD_LOADER_DISABLE_OPENCLON12`.
+This variable should only be used when building an import lib to link with, and must be enabled when building an OpenCL ICD Loader for distribution!
+
 ### Build and Install Directories
 
 A common convention is to place the `build` directory in the top directory of the repository and to place the `install` directory as a child of the `build` directory.

--- a/loader/windows/icd_windows_apppackage.cpp
+++ b/loader/windows/icd_windows_apppackage.cpp
@@ -22,6 +22,16 @@ extern "C"
 #include "icd_windows.h"
 }
 
+#ifdef OPENCL_ICD_LOADER_DISABLE_OPENCLON12
+
+extern "C" bool khrIcdOsVendorsEnumerateAppPackage()
+{
+    KHR_ICD_TRACE("OpenCLOn12 is disabled\n");
+    return false;
+}
+
+#else
+
 #include "icd_windows_apppackage.h"
 
 #include <windows.management.deployment.h>
@@ -48,10 +58,6 @@ using namespace Microsoft::WRL::Wrappers;
 
 extern "C" bool khrIcdOsVendorsEnumerateAppPackage()
 {
-#ifdef OPENCL_ICD_LOADER_DISABLE_OPENCLON12
-    KHR_ICD_TRACE("OpenCLOn12 is disabled\n");
-    return false;
-#else
     HRESULT hrInit = Windows::Foundation::Initialize(RO_INIT_MULTITHREADED);
     if (hrInit == RPC_E_CHANGED_MODE)
     {
@@ -168,5 +174,6 @@ extern "C" bool khrIcdOsVendorsEnumerateAppPackage()
         return true;
     }
     return false;
-#endif
 }
+
+#endif

--- a/loader/windows/icd_windows_apppackage.cpp
+++ b/loader/windows/icd_windows_apppackage.cpp
@@ -48,6 +48,10 @@ using namespace Microsoft::WRL::Wrappers;
 
 extern "C" bool khrIcdOsVendorsEnumerateAppPackage()
 {
+#ifdef OPENCL_ICD_LOADER_DISABLE_OPENCLON12
+    KHR_ICD_TRACE("OpenCLOn12 is disabled\n");
+    return false;
+#else
     HRESULT hrInit = Windows::Foundation::Initialize(RO_INIT_MULTITHREADED);
     if (hrInit == RPC_E_CHANGED_MODE)
     {
@@ -164,4 +168,5 @@ extern "C" bool khrIcdOsVendorsEnumerateAppPackage()
         return true;
     }
     return false;
+#endif
 }


### PR DESCRIPTION
This PR adds a CMake option to disable support for the OpenCLOn12 ICD, which reduces the build dependencies for the OpenCL ICD loader.  This option should NOT be used for building an OpenCL ICD loader DLL for distribution, but it can be used to generate a DLL import library to link against.

See #107.

I am marking this PR WIP until we can verify it solves #107 and there is no better solution.