### PR TITLE
add clSetContextDestructorCallback

### DIFF
--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -239,6 +239,26 @@ clGetContextInfo(cl_context         context,
         param_value_size_ret);
 }
 
+#ifdef CL_VERSION_3_0
+/* ICD loader entry points should not normally be ifdef'ed, but prevent
+ * OpenCL 3.0 provisional entry points from being in general builds before the
+ * specification is finalized. */
+
+CL_API_ENTRY cl_int CL_API_CALL
+clSetContextDestructorCallback(cl_context         context,
+                               void (CL_CALLBACK* pfn_notify)(cl_context context,
+                                                              void* user_data),
+                               void*              user_data) CL_API_SUFFIX__VERSION_3_0
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
+    return context->dispatch->clSetContextDestructorCallback(
+        context,
+        pfn_notify,
+        user_data);
+}
+
+#endif  // CL_VERSION_3_0
+
 // Command Queue APIs
 CL_API_ENTRY cl_command_queue CL_API_CALL
 clCreateCommandQueue(cl_context                     context, 

--- a/loader/linux/icd_exports.map.in
+++ b/loader/linux/icd_exports.map.in
@@ -169,5 +169,6 @@ OPENCL_3.0 {
     global:
         clCreateBufferWithProperties;
         clCreateImageWithProperties;
+        clSetContextDestructorCallback;
 } OPENCL_2.2;
 @ENABLE_OPENCL30_SYMBOLS_END@

--- a/loader/windows/OpenCL.def.in
+++ b/loader/windows/OpenCL.def.in
@@ -163,3 +163,4 @@ clSetProgramSpecializationConstant
 ; OpenCL 3.0 API
 @ENABLE_OPENCL30_SYMBOLS@clCreateBufferWithProperties
 @ENABLE_OPENCL30_SYMBOLS@clCreateImageWithProperties
+@ENABLE_OPENCL30_SYMBOLS@clSetContextDestructorCallback

--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -368,10 +368,10 @@ clSetContextDestructorCallback(cl_context         context,
                       context,
                       pfn_notify,
                       user_data);
-    pfn_notify(context, NULL);
+    pfn_notify(context, user_data);
     test_icd_stub_log("setcontextdestructor_callback(%p, %p)\n",
                context,
-               NULL);
+               user_data);
 
     test_icd_stub_log("Value returned: %d\n", return_value);
     return return_value;
@@ -713,10 +713,10 @@ clSetMemObjectDestructorCallback(cl_mem  memobj ,
                       memobj,
                       pfn_notify,
                       user_data);
-    pfn_notify(memobj, NULL);
+    pfn_notify(memobj, user_data);
     test_icd_stub_log("setmemobjectdestructor_callback(%p, %p)\n",
                memobj,
-               NULL);
+               user_data);
 
     test_icd_stub_log("Value returned: %d\n", return_value);
     return return_value;

--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -355,6 +355,30 @@ clGetContextInfo(cl_context         context,
     return return_value;
 }
 
+#ifdef CL_VERSION_3_0
+
+CL_API_ENTRY cl_int CL_API_CALL
+clSetContextDestructorCallback(cl_context         context,
+                               void (CL_CALLBACK* pfn_notify)(cl_context context,
+                                                              void* user_data),
+                               void*              user_data) CL_API_SUFFIX__VERSION_3_0
+{
+    cl_int return_value = CL_OUT_OF_RESOURCES;
+    test_icd_stub_log("clSetContextDestructorCallback(%p, %p, %p)\n",
+                      context,
+                      pfn_notify,
+                      user_data);
+    pfn_notify(context, NULL);
+    test_icd_stub_log("setcontextdestructor_callback(%p, %p)\n",
+               context,
+               NULL);
+
+    test_icd_stub_log("Value returned: %d\n", return_value);
+    return return_value;
+}
+
+#endif
+
 /* Command Queue APIs */
 CL_API_ENTRY cl_command_queue CL_API_CALL
 clCreateCommandQueue(cl_context                     context,

--- a/test/driver_stub/icd.c
+++ b/test/driver_stub/icd.c
@@ -234,7 +234,9 @@ cl_int cliIcdDispatchTableCreate(CLIicdDispatchTable **outDispatchTable)
     /* OpenCL 3.0 */
     ICD_DISPATCH_TABLE_ENTRY ( clCreateBufferWithProperties );
     ICD_DISPATCH_TABLE_ENTRY ( clCreateImageWithProperties );
+    ICD_DISPATCH_TABLE_ENTRY ( clSetContextDestructorCallback );
 #else
+    ICD_DISPATCH_TABLE_ENTRY( NULL );
     ICD_DISPATCH_TABLE_ENTRY( NULL );
     ICD_DISPATCH_TABLE_ENTRY( NULL );
 #endif  // CL_VERSION_3_0

--- a/test/driver_stub/rename_api.h
+++ b/test/driver_stub/rename_api.h
@@ -104,5 +104,6 @@
 #define clCreateEventFromGLsyncKHR               ___clCreateEventFromGLsyncKHR
 #define clCreateBufferWithProperties             ___clCreateBufferWithProperties
 #define clCreateImageWithProperties              ___clCreateImageWithProperties
+#define clSetContextDestructorCallback           ___clSetContextDestructorCallback
 
 #endif /* __RENAME_API_H__ */

--- a/test/loader_test/callbacks.c
+++ b/test/loader_test/callbacks.c
@@ -11,6 +11,11 @@ void CL_CALLBACK createcontext_callback(const char* _a, const void* _b, size_t _
                     _d);
 }
 
+void CL_CALLBACK setcontextdestructor_callback(cl_context _a, void* _b)
+{
+    test_icd_app_log("setcontextdestructor_callback(%p, %p)\n", _a, _b);
+}
+
 void CL_CALLBACK setmemobjectdestructor_callback(cl_mem _a, void* _b)
 {
     test_icd_app_log("setmemobjectdestructor_callback(%p, %p)\n", 

--- a/test/loader_test/param_struct.h
+++ b/test/loader_test/param_struct.h
@@ -68,6 +68,15 @@ struct clGetContextInfo_st
     size_t *param_value_size_ret;
 };
 
+#ifdef CL_VERSION_3_0
+struct clSetContextDestructorCallback_st
+{
+    cl_context context;
+    void (CL_CALLBACK *pfn_notify)(cl_context context, void *user_data);
+    void *user_data;
+};
+#endif  // CL_VERSION_3_0
+
 struct clGetPlatformIDs_st 
 {
     cl_uint num_entries;
@@ -113,6 +122,7 @@ struct clReleaseCommandQueue_st
 #define NUM_ITEMS_clRetainContext 1
 #define NUM_ITEMS_clReleaseContext 1
 #define NUM_ITEMS_clGetContextInfo 1
+#define NUM_ITEMS_clSetContextDestructorCallback 1
 #define NUM_ITEMS_clGetPlatformIDs 1
 #define NUM_ITEMS_clGetPlatformInfo 1
 #define NUM_ITEMS_clGetDeviceIDs 1

--- a/test/loader_test/test_platforms.c
+++ b/test/loader_test/test_platforms.c
@@ -8,6 +8,8 @@ extern cl_platform_id  platform;
 
 extern cl_device_id devices;
 
+extern void CL_CALLBACK setcontextdestructor_callback(cl_context _a, void* _b);
+
 struct clRetainContext_st clRetainContextData[NUM_ITEMS_clRetainContext] =
 {
     {NULL}
@@ -18,6 +20,12 @@ struct clGetContextInfo_st clGetContextInfoData[NUM_ITEMS_clGetContextInfo] =
     {NULL, 0, 0, NULL, NULL}
 };
 
+#ifdef CL_VERSION_3_0
+struct clSetContextDestructorCallback_st clSetContextDestructorCallbackData[NUM_ITEMS_clSetContextDestructorCallback] =
+{
+    {NULL, setcontextdestructor_callback, NULL}
+};
+#endif  // CL_VERSION_3_0
 
 struct clGetPlatformInfo_st clGetPlatformInfoData[NUM_ITEMS_clGetPlatformInfo] =
 {
@@ -55,7 +63,6 @@ int test_clRetainContext(const struct clRetainContext_st* data)
 }
 
 
-
 int test_clGetContextInfo(const struct clGetContextInfo_st* data)
 {
     cl_int ret_val;
@@ -78,6 +85,31 @@ int test_clGetContextInfo(const struct clGetContextInfo_st* data)
 
     return 0;
 }
+
+
+#ifdef CL_VERSION_3_0
+int test_clSetContextDestructorCallback(
+    const struct clSetContextDestructorCallback_st* data)
+{
+    cl_int ret_val;
+
+    test_icd_app_log(
+        "clSetContextDestructorCallback(%p, %p, %p)\n",
+        context,
+        data->pfn_notify,
+        data->user_data);
+
+    ret_val = clSetContextDestructorCallback(
+        context,
+        data->pfn_notify,
+        data->user_data);
+
+    test_icd_app_log("Value returned: %d\n", ret_val);
+
+    return 0;
+}
+#endif  // CL_VERSION_3_0
+
 
 int test_clGetPlatformInfo(const struct clGetPlatformInfo_st* data)
 {
@@ -166,6 +198,12 @@ int test_platforms()
     for (i = 0;i<NUM_ITEMS_clRetainContext;i++) {
         test_clRetainContext(&clRetainContextData[i]);
     }
+
+#ifdef CL_VERSION_3_0
+    for (i = 0;i<NUM_ITEMS_clSetContextDestructorCallback;i++) {
+        test_clSetContextDestructorCallback(&clSetContextDestructorCallbackData[i]);
+    }
+#endif  // CL_VERSION_3_0
 
     for (i = 0;i<NUM_ITEMS_clGetContextInfo;i++) {
         test_clGetContextInfo(&clGetContextInfoData[i]);


### PR DESCRIPTION
Adds the recently added `clSetContextDestructorCallback` API function to the ICD loader.

See: https://github.com/KhronosGroup/OpenCL-Docs/issues/187 https://github.com/KhronosGroup/OpenCL-Docs/pull/346

Fixes #112.