### PR TITLE
Define CL_USE_DEPRECATED_OPENCL_2_{1,2}_APIS

### DIFF
--- a/loader/icd_dispatch.h
+++ b/loader/icd_dispatch.h
@@ -35,6 +35,14 @@
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 #endif
 
+#ifndef CL_USE_DEPRECATED_OPENCL_2_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_1_APIS
+#endif
+
+#ifndef CL_USE_DEPRECATED_OPENCL_2_2_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_2_APIS
+#endif
+
 // cl.h
 #include <CL/cl.h>
 


### PR DESCRIPTION
We found this because some build environments were failing after #114 was merged, since it added a deprecation suffix to `clSetProgramReleaseCallback`. The actual error indicated that the GCC deprecation attribute is not valid on function definitions, so arguably there's a bug in how we're generating the loader code, but it's not a problem in practice since we just want to ignore deprecation anyway.