### PR TITLE
do not add the API suffix macro to function definitions

### DIFF
--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -150,7 +150,7 @@ static inline cl_int clGetPlatformIDs_body(
 CL_API_ENTRY cl_int CL_API_CALL clGetPlatformIDs_disp(
     cl_uint num_entries,
     cl_platform_id* platforms,
-    cl_uint* num_platforms) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_platforms)
 {
     return clGetPlatformIDs_body(
         num_entries,
@@ -161,7 +161,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetPlatformIDs_disp(
 CL_API_ENTRY cl_int CL_API_CALL clGetPlatformIDs(
     cl_uint num_entries,
     cl_platform_id* platforms,
-    cl_uint* num_platforms) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_platforms)
 {
     // initialize the platforms (in case they have not been already)
     khrIcdInitialize();
@@ -216,14 +216,14 @@ static inline void* clGetExtensionFunctionAddress_body(
 }
 
 CL_API_ENTRY void* CL_API_CALL clGetExtensionFunctionAddress_disp(
-    const char* function_name) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    const char* function_name)
 {
     return clGetExtensionFunctionAddress_body(
         function_name);
 }
 
 CL_API_ENTRY void* CL_API_CALL clGetExtensionFunctionAddress(
-    const char* function_name) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    const char* function_name)
 {
     // make sure the ICD is initialized
     khrIcdInitialize();
@@ -239,7 +239,7 @@ CL_API_ENTRY void* CL_API_CALL clGetExtensionFunctionAddress(
 
 static inline void* clGetExtensionFunctionAddressForPlatform_body(
     cl_platform_id platform,
-    const char* function_name) CL_API_SUFFIX__VERSION_1_2
+    const char* function_name)
 {
     void* function_address = NULL;
 
@@ -263,7 +263,7 @@ static inline void* clGetExtensionFunctionAddressForPlatform_body(
 
 CL_API_ENTRY void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_disp(
     cl_platform_id platform,
-    const char* function_name) CL_API_SUFFIX__VERSION_1_2
+    const char* function_name)
 {
     return clGetExtensionFunctionAddressForPlatform_body(
         platform,
@@ -272,7 +272,7 @@ CL_API_ENTRY void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_disp(
 
 CL_API_ENTRY void* CL_API_CALL clGetExtensionFunctionAddressForPlatform(
     cl_platform_id platform,
-    const char* function_name) CL_API_SUFFIX__VERSION_1_2
+    const char* function_name)
 {
     // make sure the ICD is initialized
     khrIcdInitialize();

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -38,7 +38,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetPlatformInfo(
     cl_platform_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -65,7 +65,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetPlatformInfo_disp(
     cl_platform_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clGetPlatformInfo(
@@ -84,7 +84,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDs(
     cl_device_type device_type,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_devices)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -111,7 +111,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDs_disp(
     cl_device_type device_type,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_devices)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clGetDeviceIDs(
@@ -130,7 +130,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfo(
     cl_device_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -157,7 +157,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfo_disp(
     cl_device_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clGetDeviceInfo(
@@ -177,7 +177,7 @@ CL_API_ENTRY cl_context CL_API_CALL clCreateContext(
     const cl_device_id* devices,
     void (CL_CALLBACK* pfn_notify)(const char* errinfo, const void* private_info, size_t cb, void* user_data),
     void* user_data,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -210,7 +210,7 @@ static CL_API_ENTRY cl_context CL_API_CALL clCreateContext_disp(
     const cl_device_id* devices,
     void (CL_CALLBACK* pfn_notify)(const char* errinfo, const void* private_info, size_t cb, void* user_data),
     void* user_data,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     if (num_devices == 0 || devices == NULL) {
         KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_VALUE);
@@ -233,7 +233,7 @@ CL_API_ENTRY cl_context CL_API_CALL clCreateContextFromType(
     cl_device_type device_type,
     void (CL_CALLBACK* pfn_notify)(const char* errinfo, const void* private_info, size_t cb, void* user_data),
     void* user_data,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     khrIcdInitialize();
 #if defined(CL_ENABLE_LAYERS)
@@ -263,7 +263,7 @@ static CL_API_ENTRY cl_context CL_API_CALL clCreateContextFromType_disp(
     cl_device_type device_type,
     void (CL_CALLBACK* pfn_notify)(const char* errinfo, const void* private_info, size_t cb, void* user_data),
     void* user_data,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     khrIcdInitialize();
     cl_platform_id platform = NULL;
@@ -281,7 +281,7 @@ static CL_API_ENTRY cl_context CL_API_CALL clCreateContextFromType_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainContext(
-    cl_context context) CL_API_SUFFIX__VERSION_1_0
+    cl_context context)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -296,7 +296,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainContext(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainContext_disp(
-    cl_context context) CL_API_SUFFIX__VERSION_1_0
+    cl_context context)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clRetainContext(
@@ -307,7 +307,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainContext_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseContext(
-    cl_context context) CL_API_SUFFIX__VERSION_1_0
+    cl_context context)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -322,7 +322,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseContext(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseContext_disp(
-    cl_context context) CL_API_SUFFIX__VERSION_1_0
+    cl_context context)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clReleaseContext(
@@ -337,7 +337,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetContextInfo(
     cl_context_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -364,7 +364,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetContextInfo_disp(
     cl_context_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clGetContextInfo(
@@ -379,7 +379,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetContextInfo_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainCommandQueue(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -394,7 +394,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainCommandQueue(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainCommandQueue_disp(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clRetainCommandQueue(
@@ -405,7 +405,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainCommandQueue_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseCommandQueue(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -420,7 +420,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseCommandQueue(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseCommandQueue_disp(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clReleaseCommandQueue(
@@ -435,7 +435,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetCommandQueueInfo(
     cl_command_queue_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -462,7 +462,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetCommandQueueInfo_disp(
     cl_command_queue_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clGetCommandQueueInfo(
@@ -481,7 +481,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBuffer(
     cl_mem_flags flags,
     size_t size,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -508,7 +508,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateBuffer_disp(
     cl_mem_flags flags,
     size_t size,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateBuffer(
@@ -523,7 +523,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateBuffer_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainMemObject(
-    cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
+    cl_mem memobj)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -538,7 +538,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainMemObject(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainMemObject_disp(
-    cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
+    cl_mem memobj)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clRetainMemObject(
@@ -549,7 +549,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainMemObject_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseMemObject(
-    cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
+    cl_mem memobj)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -564,7 +564,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseMemObject(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseMemObject_disp(
-    cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
+    cl_mem memobj)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clReleaseMemObject(
@@ -580,7 +580,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetSupportedImageFormats(
     cl_mem_object_type image_type,
     cl_uint num_entries,
     cl_image_format* image_formats,
-    cl_uint* num_image_formats) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_image_formats)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -610,7 +610,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetSupportedImageFormats_disp(
     cl_mem_object_type image_type,
     cl_uint num_entries,
     cl_image_format* image_formats,
-    cl_uint* num_image_formats) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_image_formats)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clGetSupportedImageFormats(
@@ -630,7 +630,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemObjectInfo(
     cl_mem_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -657,7 +657,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetMemObjectInfo_disp(
     cl_mem_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clGetMemObjectInfo(
@@ -676,7 +676,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetImageInfo(
     cl_image_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -703,7 +703,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetImageInfo_disp(
     cl_image_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(image, CL_INVALID_MEM_OBJECT);
     return image->dispatch->clGetImageInfo(
@@ -718,7 +718,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetImageInfo_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainSampler(
-    cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0
+    cl_sampler sampler)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -733,7 +733,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainSampler(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainSampler_disp(
-    cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0
+    cl_sampler sampler)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(sampler, CL_INVALID_SAMPLER);
     return sampler->dispatch->clRetainSampler(
@@ -744,7 +744,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainSampler_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseSampler(
-    cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0
+    cl_sampler sampler)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -759,7 +759,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseSampler(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseSampler_disp(
-    cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0
+    cl_sampler sampler)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(sampler, CL_INVALID_SAMPLER);
     return sampler->dispatch->clReleaseSampler(
@@ -774,7 +774,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetSamplerInfo(
     cl_sampler_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -801,7 +801,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetSamplerInfo_disp(
     cl_sampler_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(sampler, CL_INVALID_SAMPLER);
     return sampler->dispatch->clGetSamplerInfo(
@@ -820,7 +820,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithSource(
     cl_uint count,
     const char** strings,
     const size_t* lengths,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -847,7 +847,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithSource_disp(
     cl_uint count,
     const char** strings,
     const size_t* lengths,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateProgramWithSource(
@@ -868,7 +868,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBinary(
     const size_t* lengths,
     const unsigned char** binaries,
     cl_int* binary_status,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -901,7 +901,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBinary_disp(
     const size_t* lengths,
     const unsigned char** binaries,
     cl_int* binary_status,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateProgramWithBinary(
@@ -918,7 +918,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBinary_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainProgram(
-    cl_program program) CL_API_SUFFIX__VERSION_1_0
+    cl_program program)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -933,7 +933,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainProgram(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainProgram_disp(
-    cl_program program) CL_API_SUFFIX__VERSION_1_0
+    cl_program program)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clRetainProgram(
@@ -944,7 +944,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainProgram_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseProgram(
-    cl_program program) CL_API_SUFFIX__VERSION_1_0
+    cl_program program)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -959,7 +959,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseProgram(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseProgram_disp(
-    cl_program program) CL_API_SUFFIX__VERSION_1_0
+    cl_program program)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clReleaseProgram(
@@ -975,7 +975,7 @@ CL_API_ENTRY cl_int CL_API_CALL clBuildProgram(
     const cl_device_id* device_list,
     const char* options,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_0
+    void* user_data)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1005,7 +1005,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clBuildProgram_disp(
     const cl_device_id* device_list,
     const char* options,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_0
+    void* user_data)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clBuildProgram(
@@ -1025,7 +1025,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetProgramInfo(
     cl_program_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1052,7 +1052,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetProgramInfo_disp(
     cl_program_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clGetProgramInfo(
@@ -1072,7 +1072,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetProgramBuildInfo(
     cl_program_build_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1102,7 +1102,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetProgramBuildInfo_disp(
     cl_program_build_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clGetProgramBuildInfo(
@@ -1120,7 +1120,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetProgramBuildInfo_disp(
 CL_API_ENTRY cl_kernel CL_API_CALL clCreateKernel(
     cl_program program,
     const char* kernel_name,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1141,7 +1141,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL clCreateKernel(
 static CL_API_ENTRY cl_kernel CL_API_CALL clCreateKernel_disp(
     cl_program program,
     const char* kernel_name,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(program, CL_INVALID_PROGRAM);
     return program->dispatch->clCreateKernel(
@@ -1157,7 +1157,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCreateKernelsInProgram(
     cl_program program,
     cl_uint num_kernels,
     cl_kernel* kernels,
-    cl_uint* num_kernels_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_kernels_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1181,7 +1181,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clCreateKernelsInProgram_disp(
     cl_program program,
     cl_uint num_kernels,
     cl_kernel* kernels,
-    cl_uint* num_kernels_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_kernels_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clCreateKernelsInProgram(
@@ -1195,7 +1195,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clCreateKernelsInProgram_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainKernel(
-    cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
+    cl_kernel kernel)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1210,7 +1210,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainKernel(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainKernel_disp(
-    cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
+    cl_kernel kernel)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clRetainKernel(
@@ -1221,7 +1221,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainKernel_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseKernel(
-    cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
+    cl_kernel kernel)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1236,7 +1236,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseKernel(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseKernel_disp(
-    cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
+    cl_kernel kernel)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clReleaseKernel(
@@ -1250,7 +1250,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArg(
     cl_kernel kernel,
     cl_uint arg_index,
     size_t arg_size,
-    const void* arg_value) CL_API_SUFFIX__VERSION_1_0
+    const void* arg_value)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1274,7 +1274,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetKernelArg_disp(
     cl_kernel kernel,
     cl_uint arg_index,
     size_t arg_size,
-    const void* arg_value) CL_API_SUFFIX__VERSION_1_0
+    const void* arg_value)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clSetKernelArg(
@@ -1292,7 +1292,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelInfo(
     cl_kernel_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1319,7 +1319,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetKernelInfo_disp(
     cl_kernel_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clGetKernelInfo(
@@ -1339,7 +1339,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelWorkGroupInfo(
     cl_kernel_work_group_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1369,7 +1369,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetKernelWorkGroupInfo_disp(
     cl_kernel_work_group_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clGetKernelWorkGroupInfo(
@@ -1386,7 +1386,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetKernelWorkGroupInfo_disp(
 
 CL_API_ENTRY cl_int CL_API_CALL clWaitForEvents(
     cl_uint num_events,
-    const cl_event* event_list) CL_API_SUFFIX__VERSION_1_0
+    const cl_event* event_list)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1407,7 +1407,7 @@ CL_API_ENTRY cl_int CL_API_CALL clWaitForEvents(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clWaitForEvents_disp(
     cl_uint num_events,
-    const cl_event* event_list) CL_API_SUFFIX__VERSION_1_0
+    const cl_event* event_list)
 {
     if (num_events == 0 || event_list == NULL) {
         return CL_INVALID_VALUE;
@@ -1426,7 +1426,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetEventInfo(
     cl_event_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1453,7 +1453,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetEventInfo_disp(
     cl_event_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clGetEventInfo(
@@ -1468,7 +1468,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetEventInfo_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainEvent(
-    cl_event event) CL_API_SUFFIX__VERSION_1_0
+    cl_event event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1483,7 +1483,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainEvent(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainEvent_disp(
-    cl_event event) CL_API_SUFFIX__VERSION_1_0
+    cl_event event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clRetainEvent(
@@ -1494,7 +1494,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainEvent_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseEvent(
-    cl_event event) CL_API_SUFFIX__VERSION_1_0
+    cl_event event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1509,7 +1509,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseEvent(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseEvent_disp(
-    cl_event event) CL_API_SUFFIX__VERSION_1_0
+    cl_event event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clReleaseEvent(
@@ -1524,7 +1524,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetEventProfilingInfo(
     cl_profiling_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1551,7 +1551,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetEventProfilingInfo_disp(
     cl_profiling_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clGetEventProfilingInfo(
@@ -1566,7 +1566,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetEventProfilingInfo_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clFlush(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1581,7 +1581,7 @@ CL_API_ENTRY cl_int CL_API_CALL clFlush(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clFlush_disp(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clFlush(
@@ -1592,7 +1592,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clFlush_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clFinish(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1607,7 +1607,7 @@ CL_API_ENTRY cl_int CL_API_CALL clFinish(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clFinish_disp(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
+    cl_command_queue command_queue)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clFinish(
@@ -1626,7 +1626,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadBuffer(
     void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1665,7 +1665,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadBuffer_disp(
     void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReadBuffer(
@@ -1692,7 +1692,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBuffer(
     const void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1731,7 +1731,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBuffer_disp(
     const void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueWriteBuffer(
@@ -1758,7 +1758,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBuffer(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1797,7 +1797,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBuffer_disp(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueCopyBuffer(
@@ -1826,7 +1826,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadImage(
     void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1871,7 +1871,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadImage_disp(
     void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReadImage(
@@ -1902,7 +1902,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteImage(
     const void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -1947,7 +1947,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteImage_disp(
     const void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueWriteImage(
@@ -1976,7 +1976,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImage(
     const size_t* region,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2015,7 +2015,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImage_disp(
     const size_t* region,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueCopyImage(
@@ -2042,7 +2042,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImageToBuffer(
     size_t dst_offset,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2081,7 +2081,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImageToBuffer_disp(
     size_t dst_offset,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueCopyImageToBuffer(
@@ -2108,7 +2108,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferToImage(
     const size_t* region,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2147,7 +2147,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferToImage_disp(
     const size_t* region,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueCopyBufferToImage(
@@ -2175,7 +2175,7 @@ CL_API_ENTRY void* CL_API_CALL clEnqueueMapBuffer(
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
     cl_event* event,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2217,7 +2217,7 @@ static CL_API_ENTRY void* CL_API_CALL clEnqueueMapBuffer_disp(
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
     cl_event* event,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueMapBuffer(
@@ -2248,7 +2248,7 @@ CL_API_ENTRY void* CL_API_CALL clEnqueueMapImage(
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
     cl_event* event,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2296,7 +2296,7 @@ static CL_API_ENTRY void* CL_API_CALL clEnqueueMapImage_disp(
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
     cl_event* event,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueMapImage(
@@ -2323,7 +2323,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueUnmapMemObject(
     void* mapped_ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2353,7 +2353,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueUnmapMemObject_disp(
     void* mapped_ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueUnmapMemObject(
@@ -2377,7 +2377,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueNDRangeKernel(
     const size_t* local_work_size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2416,7 +2416,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueNDRangeKernel_disp(
     const size_t* local_work_size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueNDRangeKernel(
@@ -2444,7 +2444,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueNativeKernel(
     const void** args_mem_loc,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2486,7 +2486,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueNativeKernel_disp(
     const void** args_mem_loc,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueNativeKernel(
@@ -2509,7 +2509,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetCommandQueueProperty(
     cl_command_queue command_queue,
     cl_command_queue_properties properties,
     cl_bool enable,
-    cl_command_queue_properties* old_properties) CL_API_SUFFIX__VERSION_1_0_DEPRECATED
+    cl_command_queue_properties* old_properties)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2533,7 +2533,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetCommandQueueProperty_disp(
     cl_command_queue command_queue,
     cl_command_queue_properties properties,
     cl_bool enable,
-    cl_command_queue_properties* old_properties) CL_API_SUFFIX__VERSION_1_0_DEPRECATED
+    cl_command_queue_properties* old_properties)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clSetCommandQueueProperty(
@@ -2554,7 +2554,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImage2D(
     size_t image_height,
     size_t image_row_pitch,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2590,7 +2590,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateImage2D_disp(
     size_t image_height,
     size_t image_row_pitch,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateImage2D(
@@ -2617,7 +2617,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImage3D(
     size_t image_row_pitch,
     size_t image_slice_pitch,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2659,7 +2659,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateImage3D_disp(
     size_t image_row_pitch,
     size_t image_slice_pitch,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateImage3D(
@@ -2680,7 +2680,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateImage3D_disp(
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarker(
     cl_command_queue command_queue,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2698,7 +2698,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarker(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarker_disp(
     cl_command_queue command_queue,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueMarker(
@@ -2712,7 +2712,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarker_disp(
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueWaitForEvents(
     cl_command_queue command_queue,
     cl_uint num_events,
-    const cl_event* event_list) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    const cl_event* event_list)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2733,7 +2733,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWaitForEvents(
 static CL_API_ENTRY cl_int CL_API_CALL clEnqueueWaitForEvents_disp(
     cl_command_queue command_queue,
     cl_uint num_events,
-    const cl_event* event_list) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    const cl_event* event_list)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueWaitForEvents(
@@ -2746,7 +2746,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueWaitForEvents_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrier(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_command_queue command_queue)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2761,7 +2761,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrier(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrier_disp(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_command_queue command_queue)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueBarrier(
@@ -2772,7 +2772,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrier_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clUnloadCompiler(
-    void ) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    void )
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2786,7 +2786,7 @@ CL_API_ENTRY cl_int CL_API_CALL clUnloadCompiler(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clUnloadCompiler_disp(
-    void ) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    void )
 {
     // Nothing!
     return CL_SUCCESS;
@@ -2804,7 +2804,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueue(
     cl_context context,
     cl_device_id device,
     cl_command_queue_properties properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2828,7 +2828,7 @@ static CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueue_disp(
     cl_context context,
     cl_device_id device,
     cl_command_queue_properties properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateCommandQueue(
@@ -2846,7 +2846,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL clCreateSampler(
     cl_bool normalized_coords,
     cl_addressing_mode addressing_mode,
     cl_filter_mode filter_mode,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2873,7 +2873,7 @@ static CL_API_ENTRY cl_sampler CL_API_CALL clCreateSampler_disp(
     cl_bool normalized_coords,
     cl_addressing_mode addressing_mode,
     cl_filter_mode filter_mode,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateSampler(
@@ -2892,7 +2892,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueTask(
     cl_kernel kernel,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2_DEPRECATED
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2919,7 +2919,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueTask_disp(
     cl_kernel kernel,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2_DEPRECATED
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueTask(
@@ -2938,7 +2938,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateSubBuffer(
     cl_mem_flags flags,
     cl_buffer_create_type buffer_create_type,
     const void* buffer_create_info,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -2965,7 +2965,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateSubBuffer_disp(
     cl_mem_flags flags,
     cl_buffer_create_type buffer_create_type,
     const void* buffer_create_info,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(buffer, CL_INVALID_MEM_OBJECT);
     return buffer->dispatch->clCreateSubBuffer(
@@ -2982,7 +2982,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateSubBuffer_disp(
 CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorCallback(
     cl_mem memobj,
     void (CL_CALLBACK* pfn_notify)(cl_mem memobj, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_1
+    void* user_data)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3003,7 +3003,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorCallback(
 static CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorCallback_disp(
     cl_mem memobj,
     void (CL_CALLBACK* pfn_notify)(cl_mem memobj, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_1
+    void* user_data)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clSetMemObjectDestructorCallback(
@@ -3017,7 +3017,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorCallback_disp(
 
 CL_API_ENTRY cl_event CL_API_CALL clCreateUserEvent(
     cl_context context,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3035,7 +3035,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateUserEvent(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_event CL_API_CALL clCreateUserEvent_disp(
     cl_context context,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateUserEvent(
@@ -3048,7 +3048,7 @@ static CL_API_ENTRY cl_event CL_API_CALL clCreateUserEvent_disp(
 
 CL_API_ENTRY cl_int CL_API_CALL clSetUserEventStatus(
     cl_event event,
-    cl_int execution_status) CL_API_SUFFIX__VERSION_1_1
+    cl_int execution_status)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3066,7 +3066,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetUserEventStatus(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clSetUserEventStatus_disp(
     cl_event event,
-    cl_int execution_status) CL_API_SUFFIX__VERSION_1_1
+    cl_int execution_status)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clSetUserEventStatus(
@@ -3081,7 +3081,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetEventCallback(
     cl_event event,
     cl_int command_exec_callback_type,
     void (CL_CALLBACK* pfn_notify)(cl_event event, cl_int event_command_status, void *user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_1
+    void* user_data)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3105,7 +3105,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetEventCallback_disp(
     cl_event event,
     cl_int command_exec_callback_type,
     void (CL_CALLBACK* pfn_notify)(cl_event event, cl_int event_command_status, void *user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_1
+    void* user_data)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clSetEventCallback(
@@ -3132,7 +3132,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadBufferRect(
     void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3186,7 +3186,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadBufferRect_disp(
     void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReadBufferRect(
@@ -3223,7 +3223,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBufferRect(
     const void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3277,7 +3277,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBufferRect_disp(
     const void* ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueWriteBufferRect(
@@ -3313,7 +3313,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferRect(
     size_t dst_slice_pitch,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3364,7 +3364,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferRect_disp(
     size_t dst_slice_pitch,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_1
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueCopyBufferRect(
@@ -3391,7 +3391,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevices(
     const cl_device_partition_property* properties,
     cl_uint num_devices,
     cl_device_id* out_devices,
-    cl_uint* num_devices_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_uint* num_devices_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3418,7 +3418,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevices_disp(
     const cl_device_partition_property* properties,
     cl_uint num_devices,
     cl_device_id* out_devices,
-    cl_uint* num_devices_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_uint* num_devices_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(in_device, CL_INVALID_DEVICE);
     return in_device->dispatch->clCreateSubDevices(
@@ -3433,7 +3433,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevices_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainDevice(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_2
+    cl_device_id device)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3448,7 +3448,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainDevice(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainDevice_disp(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_2
+    cl_device_id device)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clRetainDevice(
@@ -3459,7 +3459,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clRetainDevice_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseDevice(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_2
+    cl_device_id device)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3474,7 +3474,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseDevice(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseDevice_disp(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_2
+    cl_device_id device)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clReleaseDevice(
@@ -3490,7 +3490,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImage(
     const cl_image_format* image_format,
     const cl_image_desc* image_desc,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3520,7 +3520,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateImage_disp(
     const cl_image_format* image_format,
     const cl_image_desc* image_desc,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateImage(
@@ -3540,7 +3540,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBuiltInKernels(
     cl_uint num_devices,
     const cl_device_id* device_list,
     const char* kernel_names,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3567,7 +3567,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBuiltInKernels_dis
     cl_uint num_devices,
     const cl_device_id* device_list,
     const char* kernel_names,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateProgramWithBuiltInKernels(
@@ -3590,7 +3590,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCompileProgram(
     const cl_program* input_headers,
     const char** header_include_names,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_2
+    void* user_data)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3629,7 +3629,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clCompileProgram_disp(
     const cl_program* input_headers,
     const char** header_include_names,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_1_2
+    void* user_data)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clCompileProgram(
@@ -3656,7 +3656,7 @@ CL_API_ENTRY cl_program CL_API_CALL clLinkProgram(
     const cl_program* input_programs,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
     void* user_data,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3695,7 +3695,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clLinkProgram_disp(
     const cl_program* input_programs,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
     void* user_data,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clLinkProgram(
@@ -3714,7 +3714,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clLinkProgram_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clUnloadPlatformCompiler(
-    cl_platform_id platform) CL_API_SUFFIX__VERSION_1_2
+    cl_platform_id platform)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3729,7 +3729,7 @@ CL_API_ENTRY cl_int CL_API_CALL clUnloadPlatformCompiler(
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clUnloadPlatformCompiler_disp(
-    cl_platform_id platform) CL_API_SUFFIX__VERSION_1_2
+    cl_platform_id platform)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clUnloadPlatformCompiler(
@@ -3745,7 +3745,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelArgInfo(
     cl_kernel_arg_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_2
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3775,7 +3775,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetKernelArgInfo_disp(
     cl_kernel_arg_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_2
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clGetKernelArgInfo(
@@ -3799,7 +3799,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillBuffer(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3838,7 +3838,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillBuffer_disp(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueFillBuffer(
@@ -3864,7 +3864,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillImage(
     const size_t* region,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3900,7 +3900,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillImage_disp(
     const size_t* region,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueFillImage(
@@ -3924,7 +3924,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemObjects(
     cl_mem_migration_flags flags,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -3957,7 +3957,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemObjects_disp(
     cl_mem_migration_flags flags,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueMigrateMemObjects(
@@ -3977,7 +3977,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarkerWithWaitList(
     cl_command_queue command_queue,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4001,7 +4001,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarkerWithWaitList_disp(
     cl_command_queue command_queue,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueMarkerWithWaitList(
@@ -4018,7 +4018,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrierWithWaitList(
     cl_command_queue command_queue,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4042,7 +4042,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrierWithWaitList_disp(
     cl_command_queue command_queue,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueBarrierWithWaitList(
@@ -4065,7 +4065,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties(
     cl_context context,
     cl_device_id device,
     const cl_queue_properties* properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4089,7 +4089,7 @@ static CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropert
     cl_context context,
     cl_device_id device,
     const cl_queue_properties* properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateCommandQueueWithProperties(
@@ -4108,7 +4108,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreatePipe(
     cl_uint pipe_packet_size,
     cl_uint pipe_max_packets,
     const cl_pipe_properties* properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4138,7 +4138,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreatePipe_disp(
     cl_uint pipe_packet_size,
     cl_uint pipe_max_packets,
     const cl_pipe_properties* properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreatePipe(
@@ -4158,7 +4158,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetPipeInfo(
     cl_pipe_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4185,7 +4185,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetPipeInfo_disp(
     cl_pipe_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(pipe, CL_INVALID_MEM_OBJECT);
     return pipe->dispatch->clGetPipeInfo(
@@ -4203,7 +4203,7 @@ CL_API_ENTRY void* CL_API_CALL clSVMAlloc(
     cl_context context,
     cl_svm_mem_flags flags,
     size_t size,
-    cl_uint alignment) CL_API_SUFFIX__VERSION_2_0
+    cl_uint alignment)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4227,7 +4227,7 @@ static CL_API_ENTRY void* CL_API_CALL clSVMAlloc_disp(
     cl_context context,
     cl_svm_mem_flags flags,
     size_t size,
-    cl_uint alignment) CL_API_SUFFIX__VERSION_2_0
+    cl_uint alignment)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, NULL);
     return context->dispatch->clSVMAlloc(
@@ -4242,7 +4242,7 @@ static CL_API_ENTRY void* CL_API_CALL clSVMAlloc_disp(
 
 CL_API_ENTRY void CL_API_CALL clSVMFree(
     cl_context context,
-    void* svm_pointer) CL_API_SUFFIX__VERSION_2_0
+    void* svm_pointer)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4263,7 +4263,7 @@ CL_API_ENTRY void CL_API_CALL clSVMFree(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY void CL_API_CALL clSVMFree_disp(
     cl_context context,
-    void* svm_pointer) CL_API_SUFFIX__VERSION_2_0
+    void* svm_pointer)
 {
     if (context == NULL) return;
     context->dispatch->clSVMFree(
@@ -4277,7 +4277,7 @@ static CL_API_ENTRY void CL_API_CALL clSVMFree_disp(
 CL_API_ENTRY cl_sampler CL_API_CALL clCreateSamplerWithProperties(
     cl_context context,
     const cl_sampler_properties* sampler_properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4298,7 +4298,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL clCreateSamplerWithProperties(
 static CL_API_ENTRY cl_sampler CL_API_CALL clCreateSamplerWithProperties_disp(
     cl_context context,
     const cl_sampler_properties* sampler_properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateSamplerWithProperties(
@@ -4313,7 +4313,7 @@ static CL_API_ENTRY cl_sampler CL_API_CALL clCreateSamplerWithProperties_disp(
 CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer(
     cl_kernel kernel,
     cl_uint arg_index,
-    const void* arg_value) CL_API_SUFFIX__VERSION_2_0
+    const void* arg_value)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4334,7 +4334,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer(
 static CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer_disp(
     cl_kernel kernel,
     cl_uint arg_index,
-    const void* arg_value) CL_API_SUFFIX__VERSION_2_0
+    const void* arg_value)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clSetKernelArgSVMPointer(
@@ -4350,7 +4350,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelExecInfo(
     cl_kernel kernel,
     cl_kernel_exec_info param_name,
     size_t param_value_size,
-    const void* param_value) CL_API_SUFFIX__VERSION_2_0
+    const void* param_value)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4374,7 +4374,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetKernelExecInfo_disp(
     cl_kernel kernel,
     cl_kernel_exec_info param_name,
     size_t param_value_size,
-    const void* param_value) CL_API_SUFFIX__VERSION_2_0
+    const void* param_value)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clSetKernelExecInfo(
@@ -4395,7 +4395,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMFree(
     void* user_data,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4431,7 +4431,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMFree_disp(
     void* user_data,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueSVMFree(
@@ -4456,7 +4456,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemcpy(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4492,7 +4492,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemcpy_disp(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueSVMMemcpy(
@@ -4517,7 +4517,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemFill(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4553,7 +4553,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemFill_disp(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueSVMMemFill(
@@ -4578,7 +4578,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMap(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4614,7 +4614,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMap_disp(
     size_t size,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueSVMMap(
@@ -4636,7 +4636,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMUnmap(
     void* svm_ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4663,7 +4663,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMUnmap_disp(
     void* svm_ptr,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueSVMUnmap(
@@ -4680,7 +4680,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMUnmap_disp(
 CL_API_ENTRY cl_int CL_API_CALL clSetDefaultDeviceCommandQueue(
     cl_context context,
     cl_device_id device,
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_2_1
+    cl_command_queue command_queue)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4701,7 +4701,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetDefaultDeviceCommandQueue(
 static CL_API_ENTRY cl_int CL_API_CALL clSetDefaultDeviceCommandQueue_disp(
     cl_context context,
     cl_device_id device,
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_2_1
+    cl_command_queue command_queue)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clSetDefaultDeviceCommandQueue(
@@ -4716,7 +4716,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetDefaultDeviceCommandQueue_disp(
 CL_API_ENTRY cl_int CL_API_CALL clGetDeviceAndHostTimer(
     cl_device_id device,
     cl_ulong* device_timestamp,
-    cl_ulong* host_timestamp) CL_API_SUFFIX__VERSION_2_1
+    cl_ulong* host_timestamp)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4737,7 +4737,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceAndHostTimer(
 static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceAndHostTimer_disp(
     cl_device_id device,
     cl_ulong* device_timestamp,
-    cl_ulong* host_timestamp) CL_API_SUFFIX__VERSION_2_1
+    cl_ulong* host_timestamp)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clGetDeviceAndHostTimer(
@@ -4751,7 +4751,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceAndHostTimer_disp(
 
 CL_API_ENTRY cl_int CL_API_CALL clGetHostTimer(
     cl_device_id device,
-    cl_ulong* host_timestamp) CL_API_SUFFIX__VERSION_2_1
+    cl_ulong* host_timestamp)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4769,7 +4769,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetHostTimer(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clGetHostTimer_disp(
     cl_device_id device,
-    cl_ulong* host_timestamp) CL_API_SUFFIX__VERSION_2_1
+    cl_ulong* host_timestamp)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clGetHostTimer(
@@ -4784,7 +4784,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithIL(
     cl_context context,
     const void* il,
     size_t length,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_1
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4808,7 +4808,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithIL_disp(
     cl_context context,
     const void* il,
     size_t length,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_1
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateProgramWithIL(
@@ -4823,7 +4823,7 @@ static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithIL_disp(
 
 CL_API_ENTRY cl_kernel CL_API_CALL clCloneKernel(
     cl_kernel source_kernel,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_1
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4841,7 +4841,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL clCloneKernel(
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_kernel CL_API_CALL clCloneKernel_disp(
     cl_kernel source_kernel,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_1
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(source_kernel, CL_INVALID_KERNEL);
     return source_kernel->dispatch->clCloneKernel(
@@ -4860,7 +4860,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfo(
     const void* input_value,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_1
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4896,7 +4896,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfo_disp(
     const void* input_value,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_1
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clGetKernelSubGroupInfo(
@@ -4921,7 +4921,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMigrateMem(
     cl_mem_migration_flags flags,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_1
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -4957,7 +4957,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMigrateMem_disp(
     cl_mem_migration_flags flags,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_2_1
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueSVMMigrateMem(
@@ -4978,7 +4978,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetProgramSpecializationConstant(
     cl_program program,
     cl_uint spec_id,
     size_t spec_size,
-    const void* spec_value) CL_API_SUFFIX__VERSION_2_2
+    const void* spec_value)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5002,7 +5002,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetProgramSpecializationConstant_disp(
     cl_program program,
     cl_uint spec_id,
     size_t spec_size,
-    const void* spec_value) CL_API_SUFFIX__VERSION_2_2
+    const void* spec_value)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clSetProgramSpecializationConstant(
@@ -5018,7 +5018,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetProgramSpecializationConstant_disp(
 CL_API_ENTRY cl_int CL_API_CALL clSetProgramReleaseCallback(
     cl_program program,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_2_2_DEPRECATED
+    void* user_data)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5039,7 +5039,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetProgramReleaseCallback(
 static CL_API_ENTRY cl_int CL_API_CALL clSetProgramReleaseCallback_disp(
     cl_program program,
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_2_2_DEPRECATED
+    void* user_data)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clSetProgramReleaseCallback(
@@ -5054,7 +5054,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetProgramReleaseCallback_disp(
 CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback(
     cl_context context,
     void (CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_3_0
+    void* user_data)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5075,7 +5075,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback(
 static CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback_disp(
     cl_context context,
     void (CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_3_0
+    void* user_data)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clSetContextDestructorCallback(
@@ -5093,7 +5093,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferWithProperties(
     cl_mem_flags flags,
     size_t size,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_3_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5123,7 +5123,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferWithProperties_disp(
     cl_mem_flags flags,
     size_t size,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_3_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateBufferWithProperties(
@@ -5145,7 +5145,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImageWithProperties(
     const cl_image_format* image_format,
     const cl_image_desc* image_desc,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_3_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5178,7 +5178,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateImageWithProperties_disp(
     const cl_image_format* image_format,
     const cl_image_desc* image_desc,
     void* host_ptr,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_3_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateImageWithProperties(
@@ -5197,7 +5197,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateImageWithProperties_disp(
 // cl_ext_device_fission
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseDeviceEXT(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_1
+    cl_device_id device)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5210,7 +5210,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseDeviceEXT(
 }
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clReleaseDeviceEXT_disp(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_1
+    cl_device_id device)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clReleaseDeviceEXT(
@@ -5219,7 +5219,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clReleaseDeviceEXT_disp(
 #endif // defined(CL_ENABLE_LAYERS)
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainDeviceEXT(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_1
+    cl_device_id device)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5232,7 +5232,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainDeviceEXT(
 }
 #if defined(CL_ENABLE_LAYERS)
 static CL_API_ENTRY cl_int CL_API_CALL clRetainDeviceEXT_disp(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_1
+    cl_device_id device)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clRetainDeviceEXT(
@@ -5245,7 +5245,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevicesEXT(
     const cl_device_partition_property_ext* properties,
     cl_uint num_entries,
     cl_device_id* out_devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_1
+    cl_uint* num_devices)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5270,7 +5270,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevicesEXT_disp(
     const cl_device_partition_property_ext* properties,
     cl_uint num_entries,
     cl_device_id* out_devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_1
+    cl_uint* num_devices)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(in_device, CL_INVALID_DEVICE);
     return in_device->dispatch->clCreateSubDevicesEXT(
@@ -5295,7 +5295,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
     cl_d3d10_device_set_khr d3d_device_set,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_devices)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5326,7 +5326,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR_disp(
     cl_d3d10_device_set_khr d3d_device_set,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_0
+    cl_uint* num_devices)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clGetDeviceIDsFromD3D10KHR(
@@ -5344,7 +5344,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
     cl_context context,
     cl_mem_flags flags,
     ID3D10Buffer* resource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5366,7 +5366,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR_disp(
     cl_context context,
     cl_mem_flags flags,
     ID3D10Buffer* resource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromD3D10BufferKHR(
@@ -5382,7 +5382,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
     cl_mem_flags flags,
     ID3D10Texture2D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5407,7 +5407,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR_disp(
     cl_mem_flags flags,
     ID3D10Texture2D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromD3D10Texture2DKHR(
@@ -5424,7 +5424,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
     cl_mem_flags flags,
     ID3D10Texture3D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5449,7 +5449,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR_disp(
     cl_mem_flags flags,
     ID3D10Texture3D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromD3D10Texture3DKHR(
@@ -5467,7 +5467,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5495,7 +5495,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueAcquireD3D10ObjectsKHR(
@@ -5514,7 +5514,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5542,7 +5542,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReleaseD3D10ObjectsKHR(
@@ -5570,7 +5570,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
     cl_d3d11_device_set_khr d3d_device_set,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_2
+    cl_uint* num_devices)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5601,7 +5601,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR_disp(
     cl_d3d11_device_set_khr d3d_device_set,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_2
+    cl_uint* num_devices)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clGetDeviceIDsFromD3D11KHR(
@@ -5619,7 +5619,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
     cl_context context,
     cl_mem_flags flags,
     ID3D11Buffer* resource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5641,7 +5641,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR_disp(
     cl_context context,
     cl_mem_flags flags,
     ID3D11Buffer* resource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromD3D11BufferKHR(
@@ -5657,7 +5657,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
     cl_mem_flags flags,
     ID3D11Texture2D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5682,7 +5682,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR_disp(
     cl_mem_flags flags,
     ID3D11Texture2D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromD3D11Texture2DKHR(
@@ -5699,7 +5699,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
     cl_mem_flags flags,
     ID3D11Texture3D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5724,7 +5724,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR_disp(
     cl_mem_flags flags,
     ID3D11Texture3D* resource,
     UINT subresource,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromD3D11Texture3DKHR(
@@ -5742,7 +5742,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5770,7 +5770,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueAcquireD3D11ObjectsKHR(
@@ -5789,7 +5789,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5817,7 +5817,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReleaseD3D11ObjectsKHR(
@@ -5846,7 +5846,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
     cl_dx9_media_adapter_set_khr media_adapter_set,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_2
+    cl_uint* num_devices)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5880,7 +5880,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR_disp
     cl_dx9_media_adapter_set_khr media_adapter_set,
     cl_uint num_entries,
     cl_device_id* devices,
-    cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_2
+    cl_uint* num_devices)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clGetDeviceIDsFromDX9MediaAdapterKHR(
@@ -5901,7 +5901,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
     cl_dx9_media_adapter_type_khr adapter_type,
     void* surface_info,
     cl_uint plane,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5929,7 +5929,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR_disp(
     cl_dx9_media_adapter_type_khr adapter_type,
     void* surface_info,
     cl_uint plane,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromDX9MediaSurfaceKHR(
@@ -5948,7 +5948,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -5976,7 +5976,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueAcquireDX9MediaSurfacesKHR(
@@ -5995,7 +5995,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6023,7 +6023,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReleaseDX9MediaSurfacesKHR(
@@ -6046,7 +6046,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromEGLSyncKHR(
     cl_context context,
     CLeglSyncKHR sync,
     CLeglDisplayKHR display,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6068,7 +6068,7 @@ static CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromEGLSyncKHR_disp(
     cl_context context,
     CLeglSyncKHR sync,
     CLeglDisplayKHR display,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateEventFromEGLSyncKHR(
@@ -6089,7 +6089,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromEGLImageKHR(
     CLeglImageKHR eglimage,
     cl_mem_flags flags,
     const cl_egl_image_properties_khr* properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6117,7 +6117,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromEGLImageKHR_disp(
     CLeglImageKHR eglimage,
     cl_mem_flags flags,
     const cl_egl_image_properties_khr* properties,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromEGLImageKHR(
@@ -6136,7 +6136,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6164,7 +6164,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueAcquireEGLObjectsKHR(
@@ -6183,7 +6183,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6211,7 +6211,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReleaseEGLObjectsKHR(
@@ -6231,7 +6231,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_disp(
 CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
     cl_context context,
     cl_GLsync sync,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6250,7 +6250,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
 static CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR_disp(
     cl_context context,
     cl_GLsync sync,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateEventFromGLsyncKHR(
@@ -6269,7 +6269,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
     cl_gl_context_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6296,7 +6296,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR_disp(
     cl_gl_context_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     cl_platform_id platform = NULL;
     khrIcdContextPropertiesGetPlatform(properties, &platform);
@@ -6314,7 +6314,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLBuffer(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint bufobj,
-    int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6336,7 +6336,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLBuffer_disp(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint bufobj,
-    int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromGLBuffer(
@@ -6353,7 +6353,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture(
     cl_GLenum target,
     cl_GLint miplevel,
     cl_GLuint texture,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6381,7 +6381,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture_disp(
     cl_GLenum target,
     cl_GLint miplevel,
     cl_GLuint texture,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromGLTexture(
@@ -6400,7 +6400,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture2D(
     cl_GLenum target,
     cl_GLint miplevel,
     cl_GLuint texture,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6428,7 +6428,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture2D_disp(
     cl_GLenum target,
     cl_GLint miplevel,
     cl_GLuint texture,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromGLTexture2D(
@@ -6447,7 +6447,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture3D(
     cl_GLenum target,
     cl_GLint miplevel,
     cl_GLuint texture,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6475,7 +6475,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture3D_disp(
     cl_GLenum target,
     cl_GLint miplevel,
     cl_GLuint texture,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromGLTexture3D(
@@ -6492,7 +6492,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint renderbuffer,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6514,7 +6514,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer_disp(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint renderbuffer,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     return context->dispatch->clCreateFromGLRenderbuffer(
@@ -6528,7 +6528,7 @@ static CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer_disp(
 CL_API_ENTRY cl_int CL_API_CALL clGetGLObjectInfo(
     cl_mem memobj,
     cl_gl_object_type* gl_object_type,
-    cl_GLuint* gl_object_name) CL_API_SUFFIX__VERSION_1_0
+    cl_GLuint* gl_object_name)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6547,7 +6547,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLObjectInfo(
 static CL_API_ENTRY cl_int CL_API_CALL clGetGLObjectInfo_disp(
     cl_mem memobj,
     cl_gl_object_type* gl_object_type,
-    cl_GLuint* gl_object_name) CL_API_SUFFIX__VERSION_1_0
+    cl_GLuint* gl_object_name)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clGetGLObjectInfo(
@@ -6562,7 +6562,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLTextureInfo(
     cl_gl_texture_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6587,7 +6587,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetGLTextureInfo_disp(
     cl_gl_texture_info param_name,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clGetGLTextureInfo(
@@ -6605,7 +6605,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireGLObjects(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6633,7 +6633,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireGLObjects_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueAcquireGLObjects(
@@ -6652,7 +6652,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseGLObjects(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6680,7 +6680,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseGLObjects_disp(
     const cl_mem* mem_objects,
     cl_uint num_events_in_wait_list,
     const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_0
+    cl_event* event)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clEnqueueReleaseGLObjects(
@@ -6705,7 +6705,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
     const void* input_value,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_0_DEPRECATED
+    size_t* param_value_size_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6739,7 +6739,7 @@ static CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_disp(
     const void* input_value,
     size_t param_value_size,
     void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_0_DEPRECATED
+    size_t* param_value_size_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(in_kernel, CL_INVALID_KERNEL);
     return in_kernel->dispatch->clGetKernelSubGroupInfoKHR(

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -68,7 +68,7 @@ ${("", "static ")[disp]}CL_API_ENTRY ${api.RetType} CL_API_CALL ${api.Name + (""
 %  if i < len(api.Params)-1:
     ${param.Type} ${param.Name}${param.TypeEnd},
 %  else:
-    ${param.Type} ${param.Name}${param.TypeEnd}) ${api.Suffix}
+    ${param.Type} ${param.Name}${param.TypeEnd})
 %  endif
 %endfor
 {
@@ -218,7 +218,7 @@ ${("", "static ")[disp]}CL_API_ENTRY ${api.RetType} CL_API_CALL ${api.Name + (""
 %  if i < len(api.Params)-1:
     ${param.Type} ${param.Name}${param.TypeEnd},
 %  else:
-    ${param.Type} ${param.Name}${param.TypeEnd}) ${api.Suffix}
+    ${param.Type} ${param.Name}${param.TypeEnd})
 %  endif
 %endfor
 {


### PR DESCRIPTION
Fixes #123 

This PR removes the API suffix macro from all ICD dispatch functions, including generated functions and manually written functions.  The API suffix macro should be included on function headers but not on function definitions.