### PR TITLE
Minor fixes to Windows build to improve header include order resiliency

### DIFF
--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -16,6 +16,8 @@
  * OpenCL is a trademark of Apple Inc. used under license by Khronos.
  */
 
+#include <initguid.h>
+
 #include "icd.h"
 #include "icd_windows.h"
 #include "icd_windows_hkr.h"
@@ -25,7 +27,6 @@
 #include <windows.h>
 #include <winreg.h>
 
-#include <initguid.h>
 #include <dxgi.h>
 typedef HRESULT (WINAPI *PFN_CREATE_DXGI_FACTORY)(REFIID, void **);
 

--- a/loader/windows/icd_windows.h
+++ b/loader/windows/icd_windows.h
@@ -19,9 +19,16 @@
 #include <stdbool.h>
 #include <windows.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern const LUID ZeroLuid;
 
 BOOL adapterAdd(const char* szName, LUID luid);
 
 // Do not free the memory returned by this function.
 const char* getOpenCLRegKeyName(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/loader/windows/icd_windows_apppackage.cpp
+++ b/loader/windows/icd_windows_apppackage.cpp
@@ -16,11 +16,8 @@
  * OpenCL is a trademark of Apple Inc. used under license by Khronos.
  */
 
-extern "C"
-{
 #include "icd.h"
 #include "icd_windows.h"
-}
 
 #ifdef OPENCL_ICD_LOADER_DISABLE_OPENCLON12
 


### PR DESCRIPTION
This fixes the errors encountered by #125 when trying to add `#include <CL/cl_icd.h>` to `icd.h`.