### PR TITLE
Remove cl_gl_ext.h includes

### DIFF
--- a/inc/README.txt
+++ b/inc/README.txt
@@ -6,7 +6,6 @@ inc/CL/cl_d3d11.h
 inc/CL/cl_dx9_media_sharing.h
 inc/CL/cl_egl.h
 inc/CL/cl_ext.h
-inc/CL/cl_gl_ext.h
 inc/CL/cl_gl.h
 inc/CL/cl.h
 inc/CL/cl.hpp

--- a/loader/icd_dispatch.h
+++ b/loader/icd_dispatch.h
@@ -56,7 +56,6 @@
 #include <CL/cl_dx9_media_sharing.h>
 #endif
 #include <CL/cl_gl.h>
-#include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
 #include <CL/cl_egl.h>
 #include <CL/cl_icd.h>

--- a/test/driver_stub/cl_gl.c
+++ b/test/driver_stub/cl_gl.c
@@ -1,5 +1,4 @@
 #include <CL/cl_gl.h>
-#include <CL/cl_gl_ext.h>
 #include <platform/icd_test_log.h>
 
 // Need to rename all CL API functions to prevent ICD loader functions calling

--- a/test/driver_stub/icd.c
+++ b/test/driver_stub/icd.c
@@ -17,7 +17,6 @@
 
 #include "CL/cl.h"
 #include "CL/cl_gl.h"
-#include "CL/cl_gl_ext.h"
 
 /*
  * Prototypes for deprecated functions no longer present in cl.h

--- a/test/loader_test/param_struct.h
+++ b/test/loader_test/param_struct.h
@@ -3,7 +3,6 @@
 
 #include<CL/cl.h>
 #include<CL/cl_gl.h>
-#include<CL/cl_gl_ext.h>
 
 struct clCreateCommandQueue_st
 {

--- a/test/loader_test/test_clgl.c
+++ b/test/loader_test/test_clgl.c
@@ -3,7 +3,6 @@
 
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
-#include <CL/cl_gl_ext.h>
 #include "param_struct.h"
 #include <platform/icd_test_log.h>
 


### PR DESCRIPTION
All OpenGL extensions are now in cl_gl.h.