### PR TITLE
Change OCL_ICD_LAYERS to OPENCL_LAYERS to conform to the specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ configuration by using the `ENABLE_OPENCL_LAYERS` (`ON` by default) cmake variab
 cmake -DENABLE_OPENCL_LAYERS=OFF
 ```
 
-For now, runtime configuration of layers is done using the `OCL_ICD_LAYERS` environment
+For now, runtime configuration of layers is done using the `OPENCL_LAYERS` environment
 variable. A colon (Linux) or semicolon (Windows) list of layers to use can be provided
 through this environment variable.
 
@@ -142,4 +142,4 @@ The following debug environment variables are available for use with the OpenCL 
 |:---------------------------------:|---------------------|----------------------|
 | OCL_ICD_FILENAMES                 | Specifies a list of additional ICDs to load.  The ICDs will be enumerated first, before any ICDs discovered via default mechanisms. | `export OCL_ICD_FILENAMES=libVendorA.so:libVendorB.so`<br/><br/>`set OCL_ICD_FILENAMES=vendor_a.dll;vendor_b.dll` |
 | OCL_ICD_VENDORS                   | On Linux and Android, specifies a directory to scan for ICDs to enumerate in place of the default `/etc/OpenCL/vendors'. |  `export OCL_ICD_VENDORS=/my/local/icd/search/path` |
-| OCL_ICD_LAYERS                    | Specifies a list of layers to load. |  `export OCL_ICD_LAYERS=libLayerA.so:libLayerB.so`<br/><br/>`set OCL_ICD_LAYERS=libLayerA.dll;libLayerB.dll` |
+| OPENCL_LAYERS                    | Specifies a list of layers to load. |  `export OPENCL_LAYERS=libLayerA.so:libLayerB.so`<br/><br/>`set OPENCL_LAYERS=libLayerA.dll;libLayerB.dll` |

--- a/loader/icd.c
+++ b/loader/icd.c
@@ -361,12 +361,12 @@ void khrIcdVendorsEnumerateEnv(void)
 #if defined(CL_ENABLE_LAYERS)
 void khrIcdLayersEnumerateEnv(void)
 {
-    char* layerFilenames = khrIcd_secure_getenv("OCL_ICD_LAYERS");
+    char* layerFilenames = khrIcd_secure_getenv("OPENCL_LAYERS");
     char* cur_file = NULL;
     char* next_file = NULL;
     if (layerFilenames)
     {
-        KHR_ICD_TRACE("Found OCL_ICD_LAYERS environment variable.\n");
+        KHR_ICD_TRACE("Found OPENCL_LAYERS environment variable.\n");
 
         next_file = layerFilenames;
         while (NULL != next_file && *next_file != '\0') {


### PR DESCRIPTION
This looks like an oversight on my part:

https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_loader_layers.asciidoc

states:

> 
>  ## New Environment Variables
> 
> A colon separated list of layer libraries that the Loader must try to load. The layers are loaded in the specified order. The most recently loaded layer will be first in the dispatch chain.
> 
> `OPENCL_LAYERS`