### PR TITLE
Add support for QNX build environment and make Linux-only functions more POSIX-like.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Notes:
 
 * Some users may prefer to use a CMake GUI frontend, such as `cmake-gui` or `ccmake`, vs. the command-line CMake.
 
+### Building on QNX
+
+QNX is using its own build system. The proper build environment must be set
+under the QNX host development system (Linux, Win64, MacOS) by invoking
+the shell/batch script provided with QNX installation. Current building environment
+under the "build-qnx" supports QNX SDP 7.0, QNX SDP 7.1 and upcoming QNX SDP 7.2.
+
 ## OpenCL ICD Loader Tests
 
 OpenCL ICD Loader Tests can be run using `ctest`, which is a companion to CMake.

--- a/build-qnx/Makefile
+++ b/build-qnx/Makefile
@@ -1,0 +1,1 @@
+include recurse.mk

--- a/build-qnx/driver_stub/Makefile
+++ b/build-qnx/driver_stub/Makefile
@@ -1,0 +1,2 @@
+LIST=OS
+include recurse.mk

--- a/build-qnx/driver_stub/common.mk
+++ b/build-qnx/driver_stub/common.mk
@@ -1,0 +1,33 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+define PINFO
+PINFO DESCRIPTION = "OpenCL Driver Stub"
+endef
+
+ICD_ROOT=$(CURDIR)/../../../../..
+
+EXTRA_INCVPATH+=$(ICD_ROOT)/inc
+EXTRA_INCVPATH+=$(ICD_ROOT)/test/inc
+
+EXTRA_SRCVPATH+=$(ICD_ROOT)/test/driver_stub
+EXTRA_SRCVPATH+=$(ICD_ROOT)/test/log
+
+NAME=libOpenCLDriverStub
+
+# Make the library
+
+SRCS = cl.c cl_ext.c cl_gl.c icd.c icd_test_log.c
+
+LDFLAGS += -Wl,--unresolved-symbols=report-all -Wl,--no-undefined -Wl,-fPIC
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CCFLAGS += -DCL_ENABLE_LAYERS -DCL_TARGET_OPENCL_VERSION=300 -DOpenCLDriverStub_EXPORTS
+CCFLAGS += -fPIC -std=gnu99
+
+CXXFLAGS += $(CCFLAGS)
+
+INSTALLDIR=usr/lib

--- a/build-qnx/driver_stub/nto/Makefile
+++ b/build-qnx/driver_stub/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/driver_stub/nto/aarch64/Makefile
+++ b/build-qnx/driver_stub/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/driver_stub/nto/aarch64/dll.le/Makefile
+++ b/build-qnx/driver_stub/nto/aarch64/dll.le/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/driver_stub/nto/arm/Makefile
+++ b/build-qnx/driver_stub/nto/arm/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/driver_stub/nto/arm/dll.le.v7/Makefile
+++ b/build-qnx/driver_stub/nto/arm/dll.le.v7/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/driver_stub/nto/x86_64/Makefile
+++ b/build-qnx/driver_stub/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/driver_stub/nto/x86_64/dll/Makefile
+++ b/build-qnx/driver_stub/nto/x86_64/dll/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/icd/Makefile
+++ b/build-qnx/icd/Makefile
@@ -1,0 +1,2 @@
+LIST=OS
+include recurse.mk

--- a/build-qnx/icd/common.mk
+++ b/build-qnx/icd/common.mk
@@ -1,0 +1,35 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+define PINFO
+PINFO DESCRIPTION = "OpenCL ICD Loader"
+endef
+
+ICD_ROOT=$(CURDIR)/../../../../..
+
+EXTRA_INCVPATH+=$(ICD_ROOT)/build_qnx
+EXTRA_INCVPATH+=$(ICD_ROOT)/inc
+
+EXTRA_SRCVPATH+=$(ICD_ROOT)/loader
+EXTRA_SRCVPATH+=$(ICD_ROOT)/loader/linux
+
+SO_VERSION=1
+NAME=OpenCL
+
+# Make the library
+
+SRCS = icd.c icd_dispatch.c icd_dispatch_generated.c icd_linux.c icd_linux_envvars.c
+
+LDFLAGS += -Wl,--unresolved-symbols=report-all -Wl,--no-undefined -Wl,-fPIC
+LDFLAGS += -Wl,--version-script -Wl,$(ICD_ROOT)/loader/linux/icd_exports.map
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CCFLAGS += -DCL_ENABLE_LAYERS -DCL_TARGET_OPENCL_VERSION=300 -DOpenCL_EXPORTS
+CCFLAGS += -fPIC -std=gnu99
+
+CXXFLAGS += $(CCFLAGS)
+
+INSTALLDIR=usr/lib

--- a/build-qnx/icd/icd_cmake_config.h
+++ b/build-qnx/icd/icd_cmake_config.h
@@ -1,0 +1,2 @@
+/* #undef HAVE_SECURE_GETENV   */
+/* #undef HAVE___SECURE_GETENV */

--- a/build-qnx/icd/nto/Makefile
+++ b/build-qnx/icd/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd/nto/aarch64/Makefile
+++ b/build-qnx/icd/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd/nto/aarch64/so.le/Makefile
+++ b/build-qnx/icd/nto/aarch64/so.le/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/icd/nto/arm/Makefile
+++ b/build-qnx/icd/nto/arm/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd/nto/arm/so.le.v7/Makefile
+++ b/build-qnx/icd/nto/arm/so.le.v7/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/icd/nto/x86_64/Makefile
+++ b/build-qnx/icd/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd/nto/x86_64/so/Makefile
+++ b/build-qnx/icd/nto/x86_64/so/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/icd_loader_test/Makefile
+++ b/build-qnx/icd_loader_test/Makefile
@@ -1,0 +1,2 @@
+LIST=OS
+include recurse.mk

--- a/build-qnx/icd_loader_test/common.mk
+++ b/build-qnx/icd_loader_test/common.mk
@@ -1,0 +1,35 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+define PINFO
+PINFO DESCRIPTION = "ICD Loader Test"
+endef
+
+ICD_ROOT=$(CURDIR)/../../../../..
+
+EXTRA_INCVPATH+=$(ICD_ROOT)/inc
+EXTRA_INCVPATH+=$(ICD_ROOT)/test/inc
+
+EXTRA_SRCVPATH+=$(ICD_ROOT)/test/loader_test
+EXTRA_SRCVPATH+=$(ICD_ROOT)/test/log
+
+NAME=icd_loader_test
+
+# Make the library
+
+SRCS = test_kernel.c main.c test_platforms.c icd_test_match.c test_program_objects.c \
+	test_sampler_objects.c test_buffer_object.c test_cl_runtime.c callbacks.c \
+	test_create_calls.c test_clgl.c test_image_objects.c icd_test_log.c
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CCFLAGS += -DCL_ENABLE_LAYERS -DCL_TARGET_OPENCL_VERSION=300
+CCFLAGS += -std=gnu99
+
+CXXFLAGS += $(CCFLAGS)
+
+LIBS += OpenCL
+
+INSTALLDIR=usr/bin

--- a/build-qnx/icd_loader_test/icd_loader_test.use
+++ b/build-qnx/icd_loader_test/icd_loader_test.use
@@ -1,0 +1,1 @@
+icd_loader_test - ICD Loader Test

--- a/build-qnx/icd_loader_test/nto/Makefile
+++ b/build-qnx/icd_loader_test/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd_loader_test/nto/aarch64/Makefile
+++ b/build-qnx/icd_loader_test/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd_loader_test/nto/aarch64/o.le/Makefile
+++ b/build-qnx/icd_loader_test/nto/aarch64/o.le/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/icd_loader_test/nto/arm/Makefile
+++ b/build-qnx/icd_loader_test/nto/arm/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd_loader_test/nto/arm/o.le.v7/Makefile
+++ b/build-qnx/icd_loader_test/nto/arm/o.le.v7/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/icd_loader_test/nto/x86_64/Makefile
+++ b/build-qnx/icd_loader_test/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/icd_loader_test/nto/x86_64/o/Makefile
+++ b/build-qnx/icd_loader_test/nto/x86_64/o/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/layer/Makefile
+++ b/build-qnx/layer/Makefile
@@ -1,0 +1,2 @@
+LIST=OS
+include recurse.mk

--- a/build-qnx/layer/common.mk
+++ b/build-qnx/layer/common.mk
@@ -1,0 +1,35 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+define PINFO
+PINFO DESCRIPTION = "OpenCL Layer Print Test"
+endef
+
+ICD_ROOT=$(CURDIR)/../../../../..
+
+EXTRA_INCVPATH+=$(ICD_ROOT)/inc
+#EXTRA_INCVPATH+=$(ICD_ROOT)/test/inc
+
+EXTRA_SRCVPATH+=$(ICD_ROOT)/test/layer
+#EXTRA_SRCVPATH+=$(ICD_ROOT)/test/log
+
+NAME=libPrintLayer
+
+# Make the library
+
+SRCS = icd_print_layer.c icd_print_layer_generated.c
+
+LDFLAGS += -Wl,--unresolved-symbols=report-all -Wl,--no-undefined -Wl,-fPIC
+LDFLAGS += -Wl,--version-script -Wl,$(ICD_ROOT)/test/layer/icd_print_layer.map
+LDFLAGS += -fvisibility=default
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CCFLAGS += -DCL_ENABLE_LAYERS -DCL_TARGET_OPENCL_VERSION=300 -DPrintLayer_EXPORTS
+CCFLAGS += -fPIC -std=gnu99
+
+CXXFLAGS += $(CCFLAGS)
+
+INSTALLDIR=usr/lib

--- a/build-qnx/layer/nto/Makefile
+++ b/build-qnx/layer/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/layer/nto/aarch64/Makefile
+++ b/build-qnx/layer/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/layer/nto/aarch64/dll.le/Makefile
+++ b/build-qnx/layer/nto/aarch64/dll.le/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/layer/nto/arm/Makefile
+++ b/build-qnx/layer/nto/arm/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/layer/nto/arm/dll.le.v7/Makefile
+++ b/build-qnx/layer/nto/arm/dll.le.v7/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build-qnx/layer/nto/x86_64/Makefile
+++ b/build-qnx/layer/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build-qnx/layer/nto/x86_64/dll/Makefile
+++ b/build-qnx/layer/nto/x86_64/dll/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/loader/icd_platform.h
+++ b/loader/icd_platform.h
@@ -19,7 +19,7 @@
 #ifndef _ICD_PLATFORM_H_
 #define _ICD_PLATFORM_H_
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__QNXNTO__)
 
 #define PATH_SEPARATOR  ':'
 #define DIRECTORY_SYMBOL '/'

--- a/loader/linux/icd_linux_envvars.c
+++ b/loader/linux/icd_linux_envvars.c
@@ -32,7 +32,7 @@ char *khrIcd_getenv(const char *name) {
 }
 
 char *khrIcd_secure_getenv(const char *name) {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__QNXNTO__)
     // Apple does not appear to have a secure getenv implementation.
     // The main difference between secure getenv and getenv is that secure getenv
     // returns NULL if the process is being run with elevated privileges by a normal user.


### PR DESCRIPTION
Hello! 

This PR consist of two patches, first adds "build-qnx" folder to the project to provide support for QNX platform, second brings more POSIX like behavior to the linux platform functions what makes them usable under any POSIX compliant OS. Not all operation systems have extended "dirent" structure to obtain filesystem entries details and type.

Thank you!
