### PR TITLE
update ICD loader generation scripts to handle empty arguments

### DIFF
--- a/scripts/gen/__init__.py
+++ b/scripts/gen/__init__.py
@@ -92,6 +92,12 @@ def get_apisigs(spec):
             ptypeend = ptypeend.strip()
             pname = pname.strip()
             plist.append(ApiParam(ptype, ptypeend, pname))
+
+        # For an empty parameter list (for e.g. clUnloadCompiler), add a single
+        # unnamed void parameter to make generation easier.
+        if len(plist) == 0:
+            plist.append(ApiParam("void", "", ""))
+
         apisigs[name] = ApiSignature(name, ret, plist, suffix)
     return apisigs
 


### PR DESCRIPTION
See: https://github.com/KhronosGroup/OpenCL-Docs/pull/593

These are the most minimal changes needed to handle APIs with no arguments in the XML file.  I tried various other solutions that preserved empty arguments and handled this case during generation, but it turned out to be much easier to just add a dummy "void" argument instead and leave the rest of the scripts unchanged.

We can investigate a different solution if needed but this should unblock the OpenCL-Docs PR mentioned above.

Tagging @Kerilk for review.