### PR TITLE
Remove const warning

### DIFF
--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -30,7 +30,7 @@
 static pthread_once_t initialized = PTHREAD_ONCE_INIT;
 
 /*
- * 
+ *
  * Vendor enumeration functions
  *
  */
@@ -52,7 +52,7 @@ void khrIcdOsVendorsEnumerate(void)
     }
 
     dir = opendir(vendorPath);
-    if (NULL == dir) 
+    if (NULL == dir)
     {
         KHR_ICD_TRACE("Failed to open path %s, continuing\n", vendorPath);
     }
@@ -153,7 +153,7 @@ void khrIcdOsVendorsEnumerateOnce(void)
 }
 
 /*
- * 
+ *
  * Dynamic library loading functions
  *
  */

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -40,7 +40,7 @@ void khrIcdOsVendorsEnumerate(void)
 {
     DIR *dir = NULL;
     struct dirent *dirEntry = NULL;
-    char* vendorPath = ICD_VENDOR_PATH;
+    const char* vendorPath = ICD_VENDOR_PATH;
     char* envPath = NULL;
 
     khrIcdVendorsEnumerateEnv();


### PR DESCRIPTION
While compiling SYCL oneAPI DPC++ from https://github.com/triSYCL/sycl/tree/sycl/unified/next I got this warning:
```
[2275/2925] Building C object _deps/ocl-icd-build/CMakeFiles/OpenCL.dir/loader/linux/icd_linux.c.o
In file included from _deps/ocl-icd-src/loader/icd.h:22,
                 from _deps/ocl-icd-src/loader/linux/icd_linux.c:19:
_deps/ocl-icd-src/loader/linux/icd_linux.c: In function ‘khrIcdOsVendorsEnumerate’:
_deps/ocl-icd-src/loader/icd_platform.h:29:25: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   29 | #define ICD_VENDOR_PATH "/etc/OpenCL/vendors";
      |                         ^~~~~~~~~~~~~~~~~~~~~
_deps/ocl-icd-src/loader/linux/icd_linux.c:43:24: note: in expansion of macro ‘ICD_VENDOR_PATH’
   43 |     char* vendorPath = ICD_VENDOR_PATH;
      |                        ^~~~~~~~~~~~~~~
```
 
This PR should fix the problem.
Perhaps we could have in the CI some compilation with modern compilers and `-Werror` on Linux?