### PR TITLE
Pedantic

### DIFF
--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -64,7 +64,7 @@ void khrIcdOsVendorsEnumerate(void)
         {
             struct stat statBuff;
             stat(dirEntry->d_name, &statBuff);
-            if(S_ISREG(statBuff.st_mode) || S_ISLNK(statBuff.st_mode))
+            if (S_ISREG(statBuff.st_mode) || S_ISLNK(statBuff.st_mode))
             {
                 const char* extension = ".icd";
                 FILE *fin = NULL;

--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -902,6 +902,7 @@ clCompileProgram(cl_program            program ,
                  void (CL_CALLBACK *   pfn_notify)(cl_program  program , void *  user_data),
                  void *                user_data) CL_API_SUFFIX__VERSION_1_2
 {
+    (void)input_headers;
     cl_int return_value = CL_OUT_OF_RESOURCES;
     test_icd_stub_log("clCompileProgram(%p, %u, %p, %p, %u, %p, %p, %p)\n",
                       program,

--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -171,7 +171,7 @@ clGetDeviceIDs(cl_platform_id   platform,
 {
     cl_int ret = CL_SUCCESS;
 
-    if ((num_entries > 1 || num_entries < 0) && devices != NULL) {
+    if ((num_entries > 1) && devices != NULL) {
         ret = CL_INVALID_VALUE;
         goto done;
     }

--- a/test/driver_stub/cl_ext.c
+++ b/test/driver_stub/cl_ext.c
@@ -10,7 +10,7 @@ struct driverStubextFunc_st
     void *func;
 };
 
-#define EXT_FUNC(name) { #name, (void*)(name) }
+#define EXT_FUNC(name) { #name, (void*)(intptr_t)(name) }
 
 static struct driverStubextFunc_st clExtensions[] = 
 {

--- a/test/driver_stub/icd.c
+++ b/test/driver_stub/icd.c
@@ -29,7 +29,7 @@ clSetCommandQueueProperty(cl_command_queue              /* command_queue */,
 
 #define ICD_DISPATCH_TABLE_ENTRY(fn) \
     assert(dispatchTable->entryCount < 256); \
-    dispatchTable->entries[dispatchTable->entryCount++] = (void*)(fn)
+    dispatchTable->entries[dispatchTable->entryCount++] = (void*)(intptr_t)(fn)
 
 cl_int cliIcdDispatchTableCreate(CLIicdDispatchTable **outDispatchTable)
 {

--- a/test/loader_test/main.c
+++ b/test/loader_test/main.c
@@ -18,6 +18,8 @@ extern int test_icd_match();
 
 int main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
     test_icd_initialize_app_log();
     test_icd_initialize_stub_log();
 

--- a/test/loader_test/param_struct.h
+++ b/test/loader_test/param_struct.h
@@ -802,7 +802,8 @@ struct clEnqueueMigrateMemObjects_st
 struct clEnqueueNDRangeKernel_st 
 {
     cl_command_queue command_queue;
-    cl_kernel kernel; cl_uint work_dim;
+    cl_kernel kernel;
+    cl_uint work_dim;
     const size_t *global_work_offset;
     const size_t *global_work_size;
     const size_t *local_work_size;  

--- a/test/loader_test/test_buffer_object.c
+++ b/test/loader_test/test_buffer_object.c
@@ -336,6 +336,7 @@ int test_clEnqueueMapBuffer(const struct clEnqueueMapBuffer_st *data)
 
 int test_clRetainMemObject(const struct clRetainMemObject_st *data)
 {
+    (void)data;
     test_icd_app_log("clRetainMemObject(%p)\n", buffer);
 
     ret_val=clRetainMemObject(buffer);

--- a/test/loader_test/test_cl_runtime.c
+++ b/test/loader_test/test_cl_runtime.c
@@ -14,6 +14,7 @@ const struct clGetCommandQueueInfo_st clGetCommandQueueInfoData[NUM_ITEMS_clGetC
 
 int test_clRetainCommandQueue(const struct clRetainCommandQueue_st *data)
 {
+    (void)data;
     cl_int ret_val;
 
     test_icd_app_log("clRetainCommandQueue(%p)\n", command_queue);

--- a/test/loader_test/test_clgl.c
+++ b/test/loader_test/test_clgl.c
@@ -268,7 +268,8 @@ int test_clCreateEventFromGLsyncKHR(const struct clCreateEventFromGLsyncKHR_st* 
                      data->sync,
                      data->errcode_ret);
 
-    pfn_clCreateEventFromGLsyncKHR = clGetExtensionFunctionAddress("clCreateEventFromGLsyncKHR");
+    pfn_clCreateEventFromGLsyncKHR = (PFN_clCreateEventFromGLsyncKHR)
+      (intptr_t)clGetExtensionFunctionAddress("clCreateEventFromGLsyncKHR");
     if (!pfn_clCreateEventFromGLsyncKHR) {
         test_icd_app_log("clGetExtensionFunctionAddress failed!\n");
         return 1;
@@ -305,7 +306,8 @@ int test_clGetGLContextInfoKHR(const struct clGetGLContextInfoKHR_st* data)
                      data->param_value,
                      data->param_value_size_ret);
 
-    pfn_clGetGLContextInfoKHR = clGetExtensionFunctionAddress("clGetGLContextInfoKHR");
+    pfn_clGetGLContextInfoKHR = (PFN_clGetGLContextInfoKHR)
+      (intptr_t)clGetExtensionFunctionAddress("clGetGLContextInfoKHR");
     if (!pfn_clGetGLContextInfoKHR) {
         test_icd_app_log("clGetExtensionFunctionAddress failed!\n");
         return 1;

--- a/test/loader_test/test_create_calls.c
+++ b/test/loader_test/test_create_calls.c
@@ -157,6 +157,8 @@ int test_clGetPlatformIDs(const struct clGetPlatformIDs_st* data)
                      data->num_entries,
                      &platforms, 
                      &num_platforms);
+#else
+    (void)data;
 #endif
 
     ret_val = clGetPlatformIDs(0,
@@ -614,6 +616,7 @@ const struct clReleaseSampler_st clReleaseSamplerData[NUM_ITEMS_clReleaseSampler
 
 int test_clReleaseSampler(const struct clReleaseSampler_st *data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES;
 
     test_icd_app_log("clReleaseSampler(%p)\n", sampler);
@@ -646,6 +649,7 @@ const struct clReleaseEvent_st clReleaseEventData[NUM_ITEMS_clReleaseEvent] =
 
 int test_clReleaseEvent(const struct clReleaseEvent_st* data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES;
 
     test_icd_app_log("clReleaseEvent(%p)\n", event);
@@ -665,6 +669,7 @@ const struct clReleaseKernel_st clReleaseKernelData[NUM_ITEMS_clReleaseKernel] =
 
 int test_clReleaseKernel(const struct clReleaseKernel_st* data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES;   
 
     test_icd_app_log("clReleaseKernel(%p)\n", kernel);
@@ -684,6 +689,7 @@ const struct clReleaseProgram_st clReleaseProgramData[NUM_ITEMS_clReleaseProgram
 
 int test_clReleaseProgram(const struct clReleaseProgram_st *data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES;
 
     test_icd_app_log("clReleaseProgram(%p)\n", program);
@@ -703,6 +709,7 @@ const struct clReleaseCommandQueue_st clReleaseCommandQueueData[NUM_ITEMS_clRele
 
 int test_clReleaseCommandQueue(const struct clReleaseCommandQueue_st *data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES;
 
     test_icd_app_log("clReleaseCommandQueue(%p)\n", command_queue);
@@ -722,6 +729,7 @@ const struct clReleaseContext_st clReleaseContextData[NUM_ITEMS_clReleaseContext
 
 int test_clReleaseContext(const struct clReleaseContext_st* data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES; 
 
     test_icd_app_log("clReleaseContext(%p)\n", context);
@@ -741,6 +749,7 @@ const struct clReleaseDevice_st clReleaseDeviceData[NUM_ITEMS_clReleaseDevice] =
 
 int test_clReleaseDevice(const struct clReleaseDevice_st* data)
 {
+    (void)data;
     int ret_val = CL_OUT_OF_RESOURCES;
 
     test_icd_app_log("clReleaseDevice(%p)\n", devices); 

--- a/test/loader_test/test_image_objects.c
+++ b/test/loader_test/test_image_objects.c
@@ -27,7 +27,7 @@ const struct clEnqueueCopyBufferToImage_st clEnqueueCopyBufferToImageData[NUM_IT
 
 const struct clEnqueueMapImage_st clEnqueueMapImageData[NUM_ITEMS_clEnqueueMapImage] =
 {
-    { NULL, NULL, 0, 0x0, NULL, NULL, NULL, NULL,0, NULL, NULL}
+    { NULL, NULL, 0, 0x0, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL}
 };
 
 const struct clEnqueueReadImage_st clEnqueueReadImageData[NUM_ITEMS_clEnqueueReadImage] =

--- a/test/loader_test/test_kernel.c
+++ b/test/loader_test/test_kernel.c
@@ -168,7 +168,7 @@ int test_clEnqueueMigrateMemObjects(const struct clEnqueueMigrateMemObjects_st* 
 
 struct clEnqueueNDRangeKernel_st clEnqueueNDRangeKernelData[NUM_ITEMS_clEnqueueNDRangeKernel] =
 {
-    {NULL, NULL, 0, NULL, NULL, NULL, 0, NULL}
+    {NULL, NULL, 0, NULL, NULL, NULL, 0, NULL, NULL}
 };
 
 int test_clEnqueueNDRangeKernel(const struct clEnqueueNDRangeKernel_st* data)

--- a/test/loader_test/test_kernel.c
+++ b/test/loader_test/test_kernel.c
@@ -26,6 +26,7 @@ struct clRetainKernel_st clRetainKernelData[NUM_ITEMS_clRetainKernel] =
 
 int test_clRetainKernel(const struct clRetainKernel_st* data)
 {
+    (void)data;
     test_icd_app_log("clRetainKernel(%p)\n", kernel);
 		
     ret_val=clRetainKernel(kernel);
@@ -345,6 +346,7 @@ struct clRetainEvent_st clRetainEventData[NUM_ITEMS_clRetainEvent] =
 
 int test_clRetainEvent(const struct clRetainEvent_st* data)
 {
+    (void)data;
     test_icd_app_log("clRetainEvent(%p)\n", event);
 
     ret_val=clRetainEvent(event);
@@ -361,6 +363,7 @@ struct clEnqueueMarker_st clEnqueueMarkerData[NUM_ITEMS_clEnqueueMarker] =
 
 int test_clEnqueueMarker(const struct clEnqueueMarker_st* data)
 {
+    (void)data;
     test_icd_app_log("clEnqueueMarker(%p, %p)\n", command_queue, &event);
 
     ret_val = clEnqueueMarker(command_queue, &event);
@@ -443,6 +446,7 @@ struct clEnqueueBarrier_st clEnqueueBarrierData[NUM_ITEMS_clEnqueueBarrier] =
 
 int test_clEnqueueBarrier(const struct clEnqueueBarrier_st* data)
 {
+    (void)data;
     test_icd_app_log("clEnqueueBarrier(%p)\n", command_queue);
 
     ret_val = clEnqueueBarrier(command_queue);
@@ -483,6 +487,7 @@ struct clFlush_st clFlushData[NUM_ITEMS_clFlush] =
 
 int test_clFlush(const struct clFlush_st* data)
 {
+    (void)data;
     test_icd_app_log("clFlush(%p)\n", command_queue);
 
     ret_val=clFlush(command_queue);
@@ -499,6 +504,7 @@ struct clFinish_st clFinishData[NUM_ITEMS_clFinish] =
 
 int test_clFinish(const struct clFinish_st* data)
 {
+    (void)data;
     test_icd_app_log("clFinish(%p)\n", command_queue);
 
     ret_val=clFinish(command_queue);

--- a/test/loader_test/test_platforms.c
+++ b/test/loader_test/test_platforms.c
@@ -49,6 +49,7 @@ struct clRetainDevice_st clRetainDeviceData[NUM_ITEMS_clRetainDevice] =
 
 int test_clRetainContext(const struct clRetainContext_st* data)
 {
+    (void)data;
     cl_int ret_val;
 
     test_icd_app_log("clRetainContext(%p)\n", context);
@@ -176,6 +177,7 @@ int test_clCreateSubDevices(const struct clCreateSubDevices_st* data)
 
 int test_clRetainDevice(const struct clRetainDevice_st* data)
 {
+    (void)data;
     cl_int ret_val;
 
     test_icd_app_log("clRetainDevice(%p)\n", devices);

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -51,6 +51,7 @@ const struct clGetProgramBuildInfo_st clGetProgramBuildInfoData[NUM_ITEMS_clGetP
 
 int test_clRetainProgram(const struct clRetainProgram_st *data)
 {
+    (void)data;
     cl_int ret_val;
 
     test_icd_app_log("clRetainProgram(%p)\n",
@@ -152,6 +153,7 @@ int test_clLinkProgram(const struct clLinkProgram_st *data)
 
 int test_clUnloadPlatformCompiler(const struct clUnloadPlatformCompiler_st *data)
 {
+    (void)data;
     cl_int ret_val;
 
     test_icd_app_log("clUnloadPlatformCompiler(%p)\n", platform);

--- a/test/loader_test/test_sampler_objects.c
+++ b/test/loader_test/test_sampler_objects.c
@@ -17,6 +17,7 @@ const struct clGetSamplerInfo_st clGetSamplerInfoData[NUM_ITEMS_clGetSamplerInfo
 
 int test_clRetainSampler(const struct clRetainSampler_st *data)
 {
+   (void)data;
     cl_int ret_val;
 
     test_icd_app_log("clRetainSampler(%p)\n", sampler);


### PR DESCRIPTION
These patches allow building the loader with very strict flags on Linux using `gcc-11.2.0`.
The flags used to test it are: 
`cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Wall -Werror -Wextra -pedantic" -DCMAKE_C_EXTENSIONS=OFF`
This PR is WIP and is intended as a strawman to solve the issues raised by https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/158