### PR TITLE
Install PDBs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,11 @@ install(
   LIBRARY
     DESTINATION ${CMAKE_INSTALL_LIBDIR} # obtained from GNUInstallDirs
 )
+install(
+  FILES $<TARGET_PDB_FILE:OpenCL>
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+  OPTIONAL
+)
 
 export(
   EXPORT OpenCLICDLoaderTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,9 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR} # obtained from GNUInstallDirs
 )
 install(
-  FILES $<TARGET_PDB_FILE:OpenCL>
+# FILES $<TARGET_PDB_FILE:OpenCL> is cleanest, but is MSVC link.exe specific. LLVM's lld.exe and lld-link.exe don't support it (configure-time error)
+# FILES $<TARGET_PROPERTY:OpenCL,COMPILE_PDB_OUTPUT_DIRECTORY>/OpenCL.pdb looks OK, but even though there's a PDB, this prop is empty on non-MSVC toolchains
+  FILES $<TARGET_FILE_DIR:OpenCL>/OpenCL.pdb # is the most implicit (expect PDB be next to the library), yet the only one that universally works
   DESTINATION ${CMAKE_INSTALL_BINDIR}
   OPTIONAL
 )


### PR DESCRIPTION
Even though console tracing is soon merged (and it's mighty useful), in some cases, for eg. when one is writing an ICD from scratch, debugging dangling pointers, mismatching levels of pointer indirection, lifetime issues, etc. attaching a debugger to the ICD is necessary. In such cases, it's useful if one can install a debug build of the ICD (typically to a non-system location) for debugging purposes.