### PR TITLE
Fix Windows compilation error for Trace mechanism

### DIFF
--- a/loader/icd.h
+++ b/loader/icd.h
@@ -84,7 +84,14 @@ struct KHRicdVendorRec
 
 // the global state
 extern KHRicdVendor * khrIcdVendors;
-extern int khrEnableTrace;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    extern int khrEnableTrace;
+#ifdef __cplusplus
+}
+#endif
 
 #if defined(CL_ENABLE_LAYERS)
 /*

--- a/loader/windows/icd_windows_apppackage.cpp
+++ b/loader/windows/icd_windows_apppackage.cpp
@@ -19,10 +19,6 @@
 #include "icd.h"
 #include "icd_windows.h"
 
-extern "C" {
-    int khrEnableTrace;
-}
-
 #ifdef OPENCL_ICD_LOADER_DISABLE_OPENCLON12
 
 extern "C" bool khrIcdOsVendorsEnumerateAppPackage()


### PR DESCRIPTION
There is compilation error for some compiler because the global variable
in header file is included by both c and cpp file.