### PR TITLE
Windows CI fix

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -113,18 +113,20 @@ jobs:
       working-directory: ${{runner.workspace}}/OpenCL-ICD-Loader/build
       shell: cmd
       run: |
-        reg ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /t REG_DWORD /d 0
+        if /I "${{matrix.BIN}}"=="x64" set REG=reg
+        if /I "${{matrix.BIN}}"=="x86" set REG=%systemroot%\Syswow64\reg.exe
+        %REG% ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /t REG_DWORD /d 0
         %CTEST_EXE% -C Release --output-on-failure --parallel %NUMBER_OF_PROCESSORS%
         if errorlevel 1 (
           exit /b %errorlevel%
         )
-        reg DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /f
-        reg ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /t REG_DWORD /d 0
+        %REG% DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /f
+        %REG% ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /t REG_DWORD /d 0
         %CTEST_EXE% -C Debug --output-on-failure --parallel %NUMBER_OF_PROCESSORS%
         if errorlevel 1 (
           exit /b %errorlevel%
         )
-        reg DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /f
+        %REG% DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /f
 
     - name: Install
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -115,9 +115,15 @@ jobs:
       run: |
         reg ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /t REG_DWORD /d 0
         %CTEST_EXE% -C Release --output-on-failure --parallel %NUMBER_OF_PROCESSORS%
+        if errorlevel 1 (
+          exit /b %errorlevel%
+        )
         reg DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /f
         reg ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /t REG_DWORD /d 0
         %CTEST_EXE% -C Debug --output-on-failure --parallel %NUMBER_OF_PROCESSORS%
+        if errorlevel 1 (
+          exit /b %errorlevel%
+        )
         reg DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /f
 
     - name: Install


### PR DESCRIPTION
It appears that our Windows CI was sometimes not failing on errors.

See this: https://github.com/KhronosGroup/OpenCL-ICD-Loader/runs/6380465198?check_suite_focus=true

where [msvc (v141, ON, Visual Studio 17 2022, x64, 90, 3.22.0)](https://github.com/KhronosGroup/OpenCL-ICD-Loader/runs/6380461806?check_suite_focus=true#logs) yields:
```
 Test project D:/a/OpenCL-ICD-Loader/OpenCL-ICD-Loader/build
    Start 1: opencl_icd_loader_test
1/1 Test #1: opencl_icd_loader_test ...........   Passed    0.09 sec
```
whereas [msvc (v143, OFF, Ninja Multi-Config, x86, 17, 3.22.0)](https://github.com/KhronosGroup/OpenCL-ICD-Loader/runs/6380465426?check_suite_focus=true#logs) yields:
```
Test project D:/a/OpenCL-ICD-Loader/OpenCL-ICD-Loader/build
    Start 1: opencl_icd_loader_test
1/1 Test #1: opencl_icd_loader_test ...........***Failed    1.20 sec
ERROR: App log and stub log differ.

APPLOG:
clGetDeviceIDs(00000000, 0, 0, 00000001, 00AE9664)
Value returned: -32
clCreateContext(00000000, 1, 00AE9664, 00AE20F0, 00000000, 00000000)
Value returned: 00000000
clReleaseContext(00000000)
```
But the test is still marked a success.
The same is true for the tip of main.

@MathiasMagnus narrowed it down to a combination of `cmd` not failing on command errors, and of improper usage of registry tools for `x86` code on `x64` platforms.

This is a quick fix that fixes the two issues.
For the first patch test expected fail) see this run https://github.com/Kerilk/OpenCL-ICD-Loader/actions/runs/2341003772
The second patch fixes the improper usage of the registry.

@MathiasMagnus suggested https://github.com/KhronosGroup/OpenCL-Layers/blob/main/utils/test_settings_location.cmake#L42-L51
as a proper fix in the longer run, but I really wanted to have something as soon as possible.