### PR TITLE
Build ICD Loader using Clang on Windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,20 +3,32 @@ name: Linux
 on: [push, pull_request]
 
 jobs:
-  cmake-minimum:
-    runs-on: ${{ matrix.OS }}
+  compatibility:
+    runs-on: ubuntu-18.04
+    container: streamhpc/opencl-sdk-intelcpu:ubuntu-18.04-20220127
     strategy:
       matrix:
-        OS: [ubuntu-18.04]
-        COMPILER: [gcc-7, gcc-8, clang-8, clang-10]
-        EXT: [ON, OFF]
+        C_COMPILER: [gcc-7, gcc-11, clang-8, clang-13]
+        CMAKE: [3.1.3]
         GEN: [Unix Makefiles]
-        CONFIG: [Debug, Release]
+        CONFIG: [Release]
+        BIN: [64, 32]
         STD: [99, 11]
-        BIN: [32, 64]
-        CMAKE: [3.1.3, 3.21.2]
+        EXT: [ON, OFF]
+        include:
+          - C_COMPILER: gcc-11
+            CMAKE: 3.22.1
+            GEN: Ninja Multi-Config
+            BIN: 64
+            STD: 17
+            EXT: OFF
+          - C_COMPILER: clang-13
+            CMAKE: 3.22.1
+            GEN: Ninja Multi-Config
+            BIN: 64
+            STD: 17
+            EXT: OFF
     env:
-      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{ matrix.CMAKE }}/cmake-${{ matrix.CMAKE }}-Linux-x86_64.tar.gz
       CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
       CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
 
@@ -31,194 +43,61 @@ jobs:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
-    - name: Create Build Environment
-      run: sudo apt-get update -q;
-        if [[ "${{matrix.GEN}}" =~ "Ninja" && ! `which ninja` ]]; then sudo apt install -y ninja-build; fi;
-        sudo apt install -y ${{matrix.COMPILER}};
-        if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "gcc" ]]; then sudo apt install -y ${{matrix.COMPILER}}-multilib; fi;
-        if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "clang" ]]; then sudo apt install -y gcc-multilib ; fi;
-        mkdir -p /opt/Kitware/CMake;
-        wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
-        mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
-      # Install Ninja only if it's the selected generator and it's not available.
-
     - name: Build & install OpenCL-Headers
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -B$GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        -H$GITHUB_WORKSPACE/external/OpenCL-Headers &&
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        --target install
-        --
-        -j`nproc`
+      shell: bash
+      run: |
+        $CMAKE_EXE \
+          -G "${{matrix.GEN}}" \
+          `if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; then echo -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}; fi;` \
+          -D BUILD_TESTING=OFF \
+          -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}" \
+          -D CMAKE_C_COMPILER=${{matrix.C_COMPILER}} \
+          -D CMAKE_C_EXTENSIONS=OFF \
+          -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install \
+          -B$GITHUB_WORKSPACE/external/OpenCL-Headers/build \
+          -H$GITHUB_WORKSPACE/external/OpenCL-Headers ;
+        $CMAKE_EXE \
+          --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build \
+          `if [[ "${{matrix.GEN}}" == "Ninja Multi-Config" ]]; then echo --config Release; fi;` \
+          --target install \
+          -- \
+          -j`nproc`
 
     - name: Configure
       shell: bash
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D BUILD_TESTING=ON
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
+        `if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; then echo -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}; fi;`
+        -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -Werror -m${{matrix.BIN}}"
+        -D CMAKE_C_COMPILER=${{matrix.C_COMPILER}}
         -D CMAKE_C_STANDARD=${{matrix.STD}}
         -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
         -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install
-        -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
+        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install"
         -B$GITHUB_WORKSPACE/build
         -H$GITHUB_WORKSPACE
 
     - name: Build
       shell: bash
-      run: $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build
-        --
-        -j`nproc`
+      run: if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]];
+        then
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build -- -j`nproc`;
+        else
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build --config Debug   -- -j`nproc`;
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build --config Release -- -j`nproc`;
+        fi;
 
     - name: Test
+      shell: bash
       working-directory: ${{runner.workspace}}/OpenCL-ICD-Loader/build
-      shell: bash
-      run: $CTEST_EXE --output-on-failure --parallel `nproc`
-
-    - name: Install
-      shell: bash
-      run: $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build
-        --target install
-        --
-        -j`nproc`
-
-    - name: "Consume (standalone): Configure/Build/Test"
-      shell: bash
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install"
-        -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/libOpenCLDriverStub.so
-        -B$GITHUB_WORKSPACE/build/downstream/bare
-        -H$GITHUB_WORKSPACE/test/pkgconfig/bare ;
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build/downstream/bare ;
-        cd $GITHUB_WORKSPACE/build/downstream/bare ;
-        $CTEST_EXE --output-on-failure
-
-    - name: "Consume (SDK): Configure/Build/Test"
-      shell: bash
-      run: $CMAKE_EXE -E make_directory $GITHUB_WORKSPACE/install/share/cmake/OpenCL ;
-        echo -e 'include("/home/runner/work/OpenCL-ICD-Loader/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake ;
-        $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install"
-        -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/libOpenCLDriverStub.so
-        -B$GITHUB_WORKSPACE/build/downstream/sdk
-        -H$GITHUB_WORKSPACE/test/pkgconfig/sdk ;
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/build/downstream/sdk ;
-        cd $GITHUB_WORKSPACE/build/downstream/sdk ;
-        $CTEST_EXE --output-on-failure
-
-
-
-
-
-  cmake-latest:
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      matrix:
-        OS : [ubuntu-20.04]
-        COMPILER: [gcc-9, gcc-11, clang-11, clang-13]
-        EXT: [ON, OFF]
-        GEN: [Ninja Multi-Config]
-        STD: [99, 11, 17]
-        BIN: [32, 64]
-        CMAKE: [3.21.2]
-    env:
-      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{ matrix.CMAKE }}/cmake-${{ matrix.CMAKE }}-Linux-x86_64.tar.gz
-      CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
-      CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
-
-
-    steps:
-    - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
-
-    - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
-      with:
-        repository: KhronosGroup/OpenCL-Headers
-        path: external/OpenCL-Headers
-
-    - name: Create Build Environment
-      run: sudo apt-get update -q;
-        if [[ "${{matrix.GEN}}" =~ "Ninja" && ! `which ninja` ]]; then sudo apt install -y ninja-build; fi;
-        if [[ "${{matrix.COMPILER}}" =~ "gcc-11" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi;
-        if [[ "${{matrix.COMPILER}}" =~ "clang-13" ]]; then wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -; sudo apt-add-repository -y 'deb [arch=amd64] https://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'; fi;
-        sudo apt install -y ${{matrix.COMPILER}};
-        if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "gcc" ]]; then sudo apt install -y ${{matrix.COMPILER}}-multilib; fi;
-        if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "clang" ]]; then sudo apt install -y gcc-multilib ; fi;
-        mkdir -p /opt/Kitware/CMake;
-        wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
-        mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
-      # Install Ninja only if it's the selected generator and it's not available.
-
-    - name: Build & install OpenCL-Headers
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -B $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        -S $GITHUB_WORKSPACE/external/OpenCL-Headers;
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        --target install
-        --config Release
-        --
-        -j`nproc`
-
-    - name: Configure
-      shell: bash
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D BUILD_TESTING=ON
-        -D CMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install
-        -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -B $GITHUB_WORKSPACE/build
-        -S $GITHUB_WORKSPACE
-
-    - name: Build
-      shell: bash
-      run: |
-        $CMAKE_EXE --build $GITHUB_WORKSPACE/build --config Release -- -j`nproc`;
-        $CMAKE_EXE --build $GITHUB_WORKSPACE/build --config Debug   -- -j`nproc`
-
-    - name: Test
-      working-directory: ${{runner.workspace}}/OpenCL-ICD-Loader/build
-      shell: bash
-      run: |
-        $CTEST_EXE --output-on-failure -C Release --parallel `nproc`;
-        $CTEST_EXE --output-on-failure -C Debug   --parallel `nproc`;
+      run: if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]];
+        then
+          $CTEST_EXE --output-on-failure --parallel `nproc`;
+        else
+          $CTEST_EXE --output-on-failure -C Debug   --parallel `nproc`;
+          $CTEST_EXE --output-on-failure -C Release --parallel `nproc`;
+        fi;
 
     - name: Install
       shell: bash
@@ -231,38 +110,62 @@ jobs:
 
     - name: "Consume (standalone): Configure/Build/Test"
       shell: bash
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install"
-        -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/Release/libOpenCLDriverStub.so
-        -B $GITHUB_WORKSPACE/build/downstream/bare
-        -S $GITHUB_WORKSPACE/test/pkgconfig/bare;
-        $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/bare --config Release;
-        $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/bare --config Debug;
-        cd $GITHUB_WORKSPACE/build/downstream/bare;
-        $CTEST_EXE --output-on-failure -C Release;
-        $CTEST_EXE --output-on-failure -C Debug;
+      run: |
+        $CMAKE_EXE \
+          -G "${{matrix.GEN}}" \
+          `if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; then echo -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}; fi;` \
+          -D CMAKE_C_COMPILER=${{matrix.C_COMPILER}} \
+          -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}" \
+          -D CMAKE_C_STANDARD=${{matrix.STD}} \
+          -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} \
+          -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install" \
+          `if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; \
+            then echo -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/libOpenCLDriverStub.so ; \
+            else echo -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/Release/libOpenCLDriverStub.so ; \
+          fi;` \
+          -B$GITHUB_WORKSPACE/build/downstream/bare \
+          -H$GITHUB_WORKSPACE/test/pkgconfig/bare ;
+        if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; \
+        then \
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/bare --config Release; \
+          cd $GITHUB_WORKSPACE/build/downstream/bare; \
+          $CTEST_EXE --output-on-failure --parallel `nproc`; \
+        else \
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/bare --config Release; \
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/bare --config Debug; \
+          cd $GITHUB_WORKSPACE/build/downstream/bare; \
+          $CTEST_EXE --output-on-failure -C Debug   --parallel `nproc`; \
+          $CTEST_EXE --output-on-failure -C Release --parallel `nproc`; \
+        fi;
 
     - name: "Consume (SDK): Configure/Build/Test"
       shell: bash
-      run: $CMAKE_EXE -E make_directory $GITHUB_WORKSPACE/install/share/cmake/OpenCL ;
-        echo -e 'include("/home/runner/work/OpenCL-ICD-Loader/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake ;
-        $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install"
-        -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/Release/libOpenCLDriverStub.so
-        -B $GITHUB_WORKSPACE/build/downstream/sdk
-        -S $GITHUB_WORKSPACE/test/pkgconfig/sdk;
-        $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/sdk --config Release;
-        $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/sdk --config Debug;
-        cd $GITHUB_WORKSPACE/build/downstream/sdk;
-        $CTEST_EXE --output-on-failure -C Release;
-        $CTEST_EXE --output-on-failure -C Debug;
+      run: |
+        $CMAKE_EXE -E make_directory $GITHUB_WORKSPACE/install/share/cmake/OpenCL ;
+        echo -e 'include("/__w/OpenCL-ICD-Loader/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake ;
+        $CMAKE_EXE \
+          -G "${{matrix.GEN}}" \
+          `if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; then echo -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}; fi;` \
+          -D CMAKE_C_COMPILER=${{matrix.C_COMPILER}} \
+          -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}" \
+          -D CMAKE_C_STANDARD=${{matrix.STD}} \
+          -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} \
+          -D CMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/external/OpenCL-Headers/install;$GITHUB_WORKSPACE/install" \
+          `if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; \
+            then echo -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/libOpenCLDriverStub.so ; \
+            else echo -D DRIVER_STUB_PATH=$GITHUB_WORKSPACE/build/Release/libOpenCLDriverStub.so ; \
+          fi;` \
+          -B$GITHUB_WORKSPACE/build/downstream/sdk \
+          -H$GITHUB_WORKSPACE/test/pkgconfig/sdk ;
+        if [[ "${{matrix.GEN}}" == "Unix Makefiles" ]]; \
+        then \
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/sdk --config Release; \
+          cd $GITHUB_WORKSPACE/build/downstream/sdk; \
+          $CTEST_EXE --output-on-failure --parallel `nproc`; \
+        else \
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/sdk --config Release; \
+          $CMAKE_EXE --build $GITHUB_WORKSPACE/build/downstream/sdk --config Debug; \
+          cd $GITHUB_WORKSPACE/build/downstream/sdk; \
+          $CTEST_EXE --output-on-failure -C Debug   --parallel `nproc`; \
+          $CTEST_EXE --output-on-failure -C Release --parallel `nproc`; \
+        fi;

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,18 +7,22 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        VER: [v141, v142, v143]
+        VER: [v142, v143]
         EXT: [ON, OFF]
-        GEN: [Visual Studio 17 2022, Ninja Multi-Config]
+        GEN: [Visual Studio 17 2022]
         BIN: [x64, x86]
-        STD: [90, 11, 17]
-        CMAKE: [3.22.0]
+        STD: [99, 11, 17]
+        include:
+          - VER: v141
+            EXT: OFF
+            GEN: Ninja Multi-Config
+            BIN: x64
+            STD: 99
     env:
-      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{matrix.CMAKE}}/cmake-${{matrix.CMAKE}}-windows-x86_64.zip
-      CMAKE_EXE: C:\Tools\Kitware\CMake\${{matrix.CMAKE}}\bin\cmake.exe
-      CTEST_EXE: C:\Tools\Kitware\CMake\${{matrix.CMAKE}}\bin\ctest.exe
       NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
-      NINJA_EXE: C:\Tools\Ninja\ninja.exe
+      NINJA_ROOT: C:\Tools\Ninja
+      VS_ROOT: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise'
+      UseMultiToolTask: true # Better parallel MSBuild execution
 
     steps:
     - name: Checkout OpenCL-ICD-Loader
@@ -30,165 +34,379 @@ jobs:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
-    - name: Create Build Environment
+    - name: Cache Ninja install
+      if: matrix.GEN == 'Ninja Multi-Config'
+      id: ninja-install
+      uses: actions/cache@v2
+      with:
+        path: |
+          C:\Tools\Ninja
+        key: ${{runner.os}}-ninja-${{env.NINJA_URL}}
+
+    - name: Install Ninja
+      if: matrix.GEN == 'Ninja Multi-Config' && steps.ninja-install.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
-        Invoke-WebRequest ${env:CMAKE_URL} -OutFile ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip
-        Expand-Archive ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip -DestinationPath C:\Tools\Kitware\CMake\
-        Rename-Item C:\Tools\Kitware\CMake\* ${{matrix.CMAKE}}
         Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
-        Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath C:\Tools\Ninja\
+        Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath ${env:NINJA_ROOT}\
         Remove-Item ~\Downloads\*
-        & ${env:CMAKE_EXE} --version
-        & ${env:NINJA_EXE} --version
 
     - name: Build & install OpenCL-Headers (MSBuild)
       if: matrix.GEN == 'Visual Studio 17 2022'
-      shell: cmd
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4 /WX"
-        if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install --config Release -- /verbosity:minimal /maxCpuCount /noLogo
+        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
+        $C_FLAGS = '/w'
+        & cmake `
+          -G '${{matrix.GEN}}' `
+          -A $BIN `
+          -T ${{matrix.VER}} `
+          -D BUILD_TESTING=OFF `
+          -D CMAKE_C_FLAGS="$C_FLAGS" `
+          -D CMAKE_C_STANDARD=${{matrix.STD}} `
+          -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} `
+          -S ${env:GITHUB_WORKSPACE}\external\OpenCL-Headers `
+          -B ${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\build
+        if ($LASTEXITCODE -ne 0) { throw "Configuring OpenCL-Headers failed." }
+        & cmake `
+          --build ${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\build `
+          --target install `
+          --config Release `
+          -- `
+          /verbosity:minimal `
+          /maxCpuCount `
+          /noLogo
+        if ($LASTEXITCODE -ne 0) { throw "Building/installing OpenCL-Headers failed." }
 
     - name: Build & install OpenCL-Headers (Ninja Multi-Config)
       if: matrix.GEN == 'Ninja Multi-Config'
-      shell: cmd
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4 /WX"
-        if /I "${{matrix.VER}}"=="v140" (set VER=14.0)
-        if /I "${{matrix.VER}}"=="v141" (set VER=14.1)
-        if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
-        if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install -- -j%NUMBER_OF_PROCESSORS%
+        $VER = switch ('${{matrix.VER}}') { `
+          'v141' {'14.1'} `
+          'v142' {'14.2'} `
+          'v143' {'14.3'} }
+        Import-Module "${env:VS_ROOT}\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+        Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=${VER}"
+        $C_FLAGS = '/w'
+        & cmake `
+          -G '${{matrix.GEN}}' `
+          -D BUILD_TESTING=OFF `
+          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D CMAKE_C_FLAGS="${C_FLAGS}" `
+          -D CMAKE_C_STANDARD=${{matrix.STD}} `
+          -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+          -D CMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install" `
+          -S ${env:GITHUB_WORKSPACE}\external\OpenCL-Headers `
+          -B ${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\build
+        if ($LASTEXITCODE -ne 0) { throw "Configuring OpenCL-Headers failed." }
+        & cmake `
+          --build ${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\build `
+          --target install `
+          --config Release `
+          -- `
+          -j ${env:NUMBER_OF_PROCESSORS}
 
     - name: Configure (MSBuild)
       if: matrix.GEN == 'Visual Studio 17 2022'
-      shell: cmd
-      # no /WX during configuration because:
-      # warning C4459: declaration of 'platform' hides global declaration
-      # warning C4100: 'input_headers': unreferenced formal parameter
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4"
-        if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D BUILD_TESTING=ON -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE% -B %GITHUB_WORKSPACE%\build
+        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
+        $C_FLAGS = '/W4 /WX'
+        $CXX_FLAGS = '/W4 /WX /EHsc'
+        & cmake `
+          -G '${{matrix.GEN}}' `
+          -A $BIN `
+          -T ${{matrix.VER}} `
+          -D OPENCL_LAYERS_BUILD_TESTING=ON `
+          -D BUILD_TESTING=ON `
+          -D CMAKE_C_FLAGS="${C_FLAGS}" `
+          -D CMAKE_C_STANDARD=${{matrix.STD}} `
+          -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+          -D CMAKE_CXX_FLAGS="${CXX_FLAGS}" `
+          -D CMAKE_CXX_EXTENSIONS='${{matrix.EXT}}' `
+          -D CMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}\install" `
+          -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install" `
+          -S "${env:GITHUB_WORKSPACE}" `
+          -B "${env:GITHUB_WORKSPACE}\build"
 
     - name: Configure (Ninja Multi-Config)
       if: matrix.GEN == 'Ninja Multi-Config'
-      shell: cmd
-      # no /WX during configuration because:
-      # warning C4459: declaration of 'platform' hides global declaration
-      # warning C4100: 'input_headers': unreferenced formal parameter
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4"
-        if /I "${{matrix.VER}}"=="v140" (set VER=14.0)
-        if /I "${{matrix.VER}}"=="v141" (set VER=14.1)
-        if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
-        if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D BUILD_TESTING=ON -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE% -B %GITHUB_WORKSPACE%\build
+        $VER = switch ('${{matrix.VER}}') { `
+          'v141' {'14.1'} `
+          'v142' {'14.2'} `
+          'v143' {'14.3'} }
+        Import-Module "${env:VS_ROOT}\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+        Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=${VER}"
+        $C_FLAGS = '/W4 /WX'
+        $CXX_FLAGS = '/W4 /WX /EHsc'
+        & cmake `
+          -G '${{matrix.GEN}}' `
+          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D OPENCL_LAYERS_BUILD_TESTING=ON `
+          -D BUILD_TESTING=ON `
+          -D CMAKE_C_FLAGS="${C_FLAGS}" `
+          -D CMAKE_C_STANDARD=${{matrix.STD}} `
+          -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+          -D CMAKE_CXX_FLAGS="${CXX_FLAGS}" `
+          -D CMAKE_CXX_EXTENSIONS='${{matrix.EXT}}' `
+          -D CMAKE_EXE_LINKER_FLAGS='/INCREMENTAL' `
+          -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install" `
+          -S "${env:GITHUB_WORKSPACE}" `
+          -B "${env:GITHUB_WORKSPACE}\build"
 
     - name: Build (MSBuild)
       if: matrix.GEN == 'Visual Studio 17 2022'
-      shell: cmd
+      shell: pwsh
       run: |
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%\build --config Release -- /verbosity:minimal /maxCpuCount /noLogo
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%\build --config Debug -- /verbosity:minimal /maxCpuCount /noLogo
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            --build "${env:GITHUB_WORKSPACE}\build" `
+            --config ${Config} `
+            -- `
+            /verbosity:minimal `
+            /maxCpuCount `
+            /noLogo
+          if ($LASTEXITCODE -ne 0) { throw "Building OpenCL-ICD-Loader in ${Config} failed." }
+        }
 
     - name: Build (Ninja)
       if: matrix.GEN == 'Ninja Multi-Config'
-      shell: cmd
+      shell: pwsh
       run: |
-        if /I "${{matrix.VER}}"=="v140" set VER=14.0
-        if /I "${{matrix.VER}}"=="v141" set VER=14.1
-        if /I "${{matrix.VER}}"=="v142" set VER=14.2
-        if /I "${{matrix.VER}}"=="v143" set VER=14.3
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%\build --config Release
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%\build --config Debug
+        $VER = switch ('${{matrix.VER}}') { `
+          'v141' {'14.1'} `
+          'v142' {'14.2'} `
+          'v143' {'14.3'} }
+        Import-Module "${env:VS_ROOT}\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+        Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=${VER}"
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            --build "${env:GITHUB_WORKSPACE}\build" `
+            --config ${Config} `
+            -- `
+            -j ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Building OpenCL-ICD-Loader in ${Config} failed." }
+        }
 
     - name: Test
-      working-directory: ${{runner.workspace}}/OpenCL-ICD-Loader/build
-      shell: cmd
+      shell: pwsh
       run: |
-        if /I "${{matrix.BIN}}"=="x64" set REG=reg
-        if /I "${{matrix.BIN}}"=="x86" set REG=%systemroot%\Syswow64\reg.exe
-        %REG% ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /t REG_DWORD /d 0
-        %CTEST_EXE% -C Release --output-on-failure --parallel %NUMBER_OF_PROCESSORS%
-        if errorlevel 1 (
-          exit /b %errorlevel%
-        )
-        %REG% DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll /f
-        %REG% ADD HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /t REG_DWORD /d 0
-        %CTEST_EXE% -C Debug --output-on-failure --parallel %NUMBER_OF_PROCESSORS%
-        if errorlevel 1 (
-          exit /b %errorlevel%
-        )
-        %REG% DELETE HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors /v %GITHUB_WORKSPACE%/build/Debug/OpenCLDriverStub.dll /f
+        $REG_PATH = if('${{matrix.BIN}}' -eq 'x86') { `
+          'HKLM:\SOFTWARE\WOW6432Node\Khronos\OpenCL\Vendors' } else { `
+          'HKLM:\SOFTWARE\Khronos\OpenCL\Vendors' }
+        New-Item -Type Directory ${REG_PATH} -Force | Out-Null
+        foreach ($Config in 'Release','Debug') { `
+          Write-Host "Running CTest on ${Config}"
+          Set-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll" -Type DWord -Value 0
+          & ctest `
+            --test-dir ${env:GITHUB_WORKSPACE}\build `
+            --build-config ${Config} `
+            --output-on-failure `
+            --no-tests=error `
+            --parallel ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Testing OpenCL-ICD-Loader in ${Config} failed." }
+          Remove-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll"
+        }
 
     - name: Install
-      shell: cmd
+      shell: pwsh
       run: |
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/build --config Release --target install
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            --install ${env:GITHUB_WORKSPACE}\build `
+            --prefix ${env:GITHUB_WORKSPACE}\install-${Config} `
+            --config ${Config}
+          if ($LASTEXITCODE -ne 0) { throw "Installing OpenCL-ICD-Loader in ${Config} failed." }
+        }
+        if (-not (Test-Path ${env:GITHUB_WORKSPACE}\install-Debug\bin\OpenCL.pdb)) { `
+          throw "No OpenCL.pdb installed"
+        }
 
     - name: "Consume (MSBuild standalone): Configure/Build/Test"
-      shell: cmd
+      if: matrix.GEN == 'Visual Studio 17 2022'
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4"
-        if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%\external\OpenCL-Headers\install;%GITHUB_WORKSPACE%\install" -D DRIVER_STUB_PATH=%GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll -B %GITHUB_WORKSPACE%/build/downstream/bare -S %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Release
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Debug
-        cd %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CTEST_EXE% --output-on-failure -C Release
-        %CTEST_EXE% --output-on-failure -C Debug
-
-    - name: "Consume (MSBuild SDK): Configure/Build/Test"
-      shell: cmd
-      run: |
-        set C_FLAGS="/W4"
-        if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        %CMAKE_EXE% -E make_directory $GITHUB_WORKSPACE/install/share/cmake/OpenCL
-        echo -e 'include("/home/runner/work/OpenCL-ICD-Loader/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%\external\OpenCL-Headers\install;%GITHUB_WORKSPACE%\install" -D DRIVER_STUB_PATH=%GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll -B %GITHUB_WORKSPACE%/build/downstream/bare -S %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Release
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Debug
-        cd %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CTEST_EXE% --output-on-failure -C Release
-        %CTEST_EXE% --output-on-failure -C Debug
+        $REG_PATH = if('${{matrix.BIN}}' -eq 'x86') { `
+          'HKLM:\SOFTWARE\WOW6432Node\Khronos\OpenCL\Vendors' } else { `
+          'HKLM:\SOFTWARE\Khronos\OpenCL\Vendors' }
+        New-Item -Type Directory ${REG_PATH} -Force | Out-Null
+        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
+        $C_FLAGS = '/W4 /WX'
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            -G '${{matrix.GEN}}' `
+            -A $BIN `
+            -T ${{matrix.VER}} `
+            -D BUILD_TESTING=ON `
+            -D CMAKE_C_FLAGS="${C_FLAGS}" `
+            -D CMAKE_C_STANDARD=${{matrix.STD}} `
+            -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+            -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
+            -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install-${Config}" `
+            -D DRIVER_STUB_PATH=${env:GITHUB_WORKSPACE}\build\Release\OpenCLDriverStub.dll `
+            -B ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            -S ${env:GITHUB_WORKSPACE}\test\pkgconfig\bare
+          if ($LASTEXITCODE -ne 0) { throw "Consuming standalone OpenCL-ICD-Loader in ${Config} failed." }
+          & cmake `
+            --build ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --config ${Config} `
+            -- `
+            /verbosity:minimal `
+            /maxCpuCount `
+            /noLogo
+          if ($LASTEXITCODE -ne 0) { throw "Consuming standalone OpenCL-ICD-Loader in ${Config} failed." }
+          Set-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll" -Type DWord -Value 0
+          & ctest `
+            --test-dir ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --build-config ${Config} `
+            --output-on-failure `
+            --no-tests=error `
+            --parallel ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Consuming standalone OpenCL-ICD-Loader in ${Config} failed." }
+          Remove-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll"
+        }
 
     - name: "Consume (Ninja-Multi-Config standalone): Configure/Build/Test"
-      shell: cmd
+      if: matrix.GEN == 'Ninja Multi-Config'
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4"
-        if /I "${{matrix.VER}}"=="v140" (set VER=14.0)
-        if /I "${{matrix.VER}}"=="v141" (set VER=14.1)
-        if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
-        if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%\external\OpenCL-Headers\install;%GITHUB_WORKSPACE%\install" -D DRIVER_STUB_PATH=%GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll -B %GITHUB_WORKSPACE%/build/downstream/bare -S %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Release
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Debug
-        cd %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CTEST_EXE% --output-on-failure -C Release
-        %CTEST_EXE% --output-on-failure -C Debug
+        $REG_PATH = if('${{matrix.BIN}}' -eq 'x86') { `
+          'HKLM:\SOFTWARE\WOW6432Node\Khronos\OpenCL\Vendors' } else { `
+          'HKLM:\SOFTWARE\Khronos\OpenCL\Vendors' }
+        New-Item -Type Directory ${REG_PATH} -Force | Out-Null
+        $VER = switch ('${{matrix.VER}}') { `
+          'v141' {'14.1'} `
+          'v142' {'14.2'} `
+          'v143' {'14.3'} }
+        Import-Module "${env:VS_ROOT}\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+        Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=${VER}"
+        $C_FLAGS = '/W4 /WX'
+        $CXX_FLAGS = '/W4 /WX /EHsc'
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            -G '${{matrix.GEN}}' `
+            -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+            -D BUILD_TESTING=ON `
+            -D CMAKE_C_FLAGS="${C_FLAGS}" `
+            -D CMAKE_C_STANDARD=${{matrix.STD}} `
+            -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+            -D CMAKE_EXE_LINKER_FLAGS='/INCREMENTAL' `
+            -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install-${Config}" `
+            -D DRIVER_STUB_PATH=${env:GITHUB_WORKSPACE}\build\Release\OpenCLDriverStub.dll `
+            -B ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            -S ${env:GITHUB_WORKSPACE}\test\pkgconfig\bare
+          if ($LASTEXITCODE -ne 0) { throw "Consuming standalone OpenCL-ICD-Loader in ${Config} failed." }
+          & cmake `
+            --build ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --config ${Config} `
+            -- `
+            -j ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Consuming standalone OpenCL-ICD-Loader in ${Config} failed." }
+          Set-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll" -Type DWord -Value 0
+          & ctest `
+            --test-dir ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --build-config ${Config} `
+            --output-on-failure `
+            --no-tests=error `
+            --parallel ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Consuming standalone OpenCL-ICD-Loader in ${Config} failed." }
+          Remove-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll"
+        }
+
+    - name: "Consume (MSBuild SDK): Configure/Build/Test"
+      if: matrix.GEN == 'Visual Studio 17 2022'
+      shell: pwsh
+      run: |
+        cmake -E make_directory $GITHUB_WORKSPACE\install\share\cmake\OpenCL ;
+        New-Item -Type File -Path $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake -Value 'include("${{runner.workspace}}/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' ;
+        $REG_PATH = if('${{matrix.BIN}}' -eq 'x86') { `
+          'HKLM:\SOFTWARE\WOW6432Node\Khronos\OpenCL\Vendors' } else { `
+          'HKLM:\SOFTWARE\Khronos\OpenCL\Vendors' }
+        New-Item -Type Directory ${REG_PATH} -Force | Out-Null
+        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
+        $C_FLAGS = '/W4 /WX'
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            -G '${{matrix.GEN}}' `
+            -A $BIN `
+            -T ${{matrix.VER}} `
+            -D BUILD_TESTING=ON `
+            -D CMAKE_C_FLAGS="${C_FLAGS}" `
+            -D CMAKE_C_STANDARD=${{matrix.STD}} `
+            -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+            -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
+            -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install-${Config}" `
+            -D DRIVER_STUB_PATH=${env:GITHUB_WORKSPACE}\build\Release\OpenCLDriverStub.dll `
+            -B ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            -S ${env:GITHUB_WORKSPACE}\test\pkgconfig\bare
+          if ($LASTEXITCODE -ne 0) { throw "Consuming SDK component OpenCL-ICD-Loader in ${Config} failed." }
+          & cmake `
+            --build ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --config ${Config} `
+            -- `
+            /verbosity:minimal `
+            /maxCpuCount `
+            /noLogo
+          if ($LASTEXITCODE -ne 0) { throw "Consuming SDK component OpenCL-ICD-Loader in ${Config} failed." }
+          Set-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll" -Type DWord -Value 0
+          & ctest `
+            --test-dir ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --build-config ${Config} `
+            --output-on-failure `
+            --no-tests=error `
+            --parallel ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Consuming SDK component OpenCL-ICD-Loader in ${Config} failed." }
+          Remove-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll"
+        }
 
     - name: "Consume (Ninja-Multi-Config SDK): Configure/Build/Test"
-      shell: cmd
+      if: matrix.GEN == 'Ninja Multi-Config'
+      shell: pwsh
       run: |
-        set C_FLAGS="/W4"
-        if /I "${{matrix.VER}}"=="v140" (set VER=14.0)
-        if /I "${{matrix.VER}}"=="v141" (set VER=14.1)
-        if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
-        if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
-        %CMAKE_EXE% -E make_directory $GITHUB_WORKSPACE/install/share/cmake/OpenCL
-        echo -e 'include("/home/runner/work/OpenCL-ICD-Loader/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' > $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install -D CMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%\external\OpenCL-Headers\install;%GITHUB_WORKSPACE%\install" -D DRIVER_STUB_PATH=%GITHUB_WORKSPACE%/build/Release/OpenCLDriverStub.dll -B %GITHUB_WORKSPACE%/build/downstream/bare -S %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Release
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/test/pkgconfig/bare --config Debug
-        cd %GITHUB_WORKSPACE%/test/pkgconfig/bare
-        %CTEST_EXE% --output-on-failure -C Release
-        %CTEST_EXE% --output-on-failure -C Debug
+        cmake -E make_directory $GITHUB_WORKSPACE\install\share\cmake\OpenCL ;
+        New-Item -Type File -Path $GITHUB_WORKSPACE/install/share/cmake/OpenCL/OpenCLConfig.cmake -Value 'include("${{runner.workspace}}/OpenCL-ICD-Loader/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake")\ninclude("${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake")' ;
+        $REG_PATH = if('${{matrix.BIN}}' -eq 'x86') { `
+          'HKLM:\SOFTWARE\WOW6432Node\Khronos\OpenCL\Vendors' } else { `
+          'HKLM:\SOFTWARE\Khronos\OpenCL\Vendors' }
+        New-Item -Type Directory ${REG_PATH} -Force | Out-Null
+        $VER = switch ('${{matrix.VER}}') { `
+          'v141' {'14.1'} `
+          'v142' {'14.2'} `
+          'v143' {'14.3'} }
+        Import-Module "${env:VS_ROOT}\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+        Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=${VER}"
+        $C_FLAGS = '/W4 /WX'
+        $CXX_FLAGS = '/W4 /WX /EHsc'
+        foreach ($Config in 'Release','Debug') { `
+          & cmake `
+            -G '${{matrix.GEN}}' `
+            -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+            -D BUILD_TESTING=ON `
+            -D CMAKE_C_FLAGS="${C_FLAGS}" `
+            -D CMAKE_C_STANDARD=${{matrix.STD}} `
+            -D CMAKE_C_EXTENSIONS='${{matrix.EXT}}' `
+            -D CMAKE_EXE_LINKER_FLAGS='/INCREMENTAL' `
+            -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install-${Config}" `
+            -D DRIVER_STUB_PATH=${env:GITHUB_WORKSPACE}\build\Release\OpenCLDriverStub.dll `
+            -B ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            -S ${env:GITHUB_WORKSPACE}\test\pkgconfig\bare
+          if ($LASTEXITCODE -ne 0) { throw "Consuming SDK component OpenCL-ICD-Loader in ${Config} failed." }
+          & cmake `
+            --build ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --config ${Config} `
+            -- `
+            -j ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Consuming SDK component OpenCL-ICD-Loader in ${Config} failed." }
+          Set-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll" -Type DWord -Value 0
+          & ctest `
+            --test-dir ${env:GITHUB_WORKSPACE}\build\downstream\bare `
+            --build-config ${Config} `
+            --output-on-failure `
+            --no-tests=error `
+            --parallel ${env:NUMBER_OF_PROCESSORS}
+          if ($LASTEXITCODE -ne 0) { throw "Consuming SDK component OpenCL-ICD-Loader in ${Config} failed." }
+          Remove-ItemProperty -Path ${REG_PATH} -Name "${env:GITHUB_WORKSPACE}\build\${Config}\OpenCLDriverStub.dll"
+        }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        VER: [v142, v143]
+        VER: [v142, v143, clangcl]
         EXT: [ON, OFF]
         GEN: [Visual Studio 17 2022]
         BIN: [x64, x86]

--- a/loader/icd_dispatch.h
+++ b/loader/icd_dispatch.h
@@ -48,9 +48,17 @@
 
 // cl_gl.h and required files
 #ifdef _WIN32
+// System headers aren't ISO compliant
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning( push )
+#pragma warning( disable : 4201 )
+#endif
 #include <windows.h>
 #include <d3d9.h>
 #include <d3d10_1.h>
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning( pop )
+#endif
 #include <CL/cl_d3d10.h>
 #include <CL/cl_d3d11.h>
 #include <CL/cl_dx9_media_sharing.h>

--- a/loader/windows/OpenCL.rc
+++ b/loader/windows/OpenCL.rc
@@ -43,7 +43,7 @@ BEGIN
         BEGIN
             VALUE "FileDescription" ,"OpenCL Client DLL"
             VALUE "ProductName"     ,"Khronos OpenCL ICD Loader"
-            VALUE "LegalCopyright"  ,"Copyright \251 The Khronos Group Inc 2016-2020"
+            VALUE "LegalCopyright"  ,L"Copyright \251 The Khronos Group Inc 2016-2020"
             VALUE "FileVersion"     ,OPENCL_ICD_LOADER_VERSION_STRING ".0"
             VALUE "CompanyName"     ,"Khronos Group"
             VALUE "InternalName"    ,"OpenCL"

--- a/loader/windows/adapter.h
+++ b/loader/windows/adapter.h
@@ -18,6 +18,15 @@
 * Author: Lenny Komow <lenny@lunarg.com>
 */
 
+// System types aren't ISO compliant
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning( push )
+#pragma warning( disable : 4201 )
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc11-extensions"
+#endif
+
 typedef struct LoaderEnumAdapters2 {
     ULONG adapter_count;
     struct {
@@ -78,3 +87,9 @@ typedef struct LoaderQueryRegistryInfo {
         BYTE output_binary[1];
     };
 } LoaderQueryRegistryInfo;
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning( pop )
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -270,7 +270,7 @@ void *khrIcdOsLibraryLoad(const char *libraryName)
     }
     if (!hTemp)
     {
-        KHR_ICD_TRACE("Failed to load driver. Windows error code is %d.\n", GetLastError());
+        KHR_ICD_TRACE("Failed to load driver. Windows error code is %lu.\n", GetLastError());
     }
     return (void*)hTemp;
 }

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -107,6 +107,9 @@ void adapterFree(WinAdapter *pWinAdapter)
 // for each vendor encountered
 BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *lpContext)
 {
+    (void)InitOnce;
+    (void)Parameter;
+    (void)lpContext;
     LONG result;
     BOOL status = FALSE;
     const char* platformsName = "SOFTWARE\\Khronos\\OpenCL\\Vendors";
@@ -279,7 +282,19 @@ void *khrIcdOsLibraryGetFunctionAddress(void *library, const char *functionName)
     {
         return NULL;
     }
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning( push )
+#pragma warning( disable : 4152 )
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#endif
     return GetProcAddress( (HMODULE)library, functionName);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning( pop )
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 // unload a library.

--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -93,7 +93,7 @@ clGetPlatformIDs(cl_uint           num_entries ,
 }
 
 CL_API_ENTRY cl_int CL_API_CALL
-clGetPlatformInfo(cl_platform_id    platform,
+clGetPlatformInfo(cl_platform_id    _platform,
                   cl_platform_info  param_name,
                   size_t            param_value_size,
                   void *            param_value,
@@ -117,22 +117,22 @@ clGetPlatformInfo(cl_platform_id    platform,
     // select the string to return
     switch(param_name) {
         case CL_PLATFORM_PROFILE:
-            returnString = platform->profile;
+            returnString = _platform->profile;
             break;
         case CL_PLATFORM_VERSION:
-            returnString = platform->version;
+            returnString = _platform->version;
             break;
         case CL_PLATFORM_NAME:
-            returnString = platform->name;
+            returnString = _platform->name;
             break;
         case CL_PLATFORM_VENDOR:
-            returnString = platform->vendor;
+            returnString = _platform->vendor;
             break;
         case CL_PLATFORM_EXTENSIONS:
-            returnString = platform->extensions;
+            returnString = _platform->extensions;
             break;
         case CL_PLATFORM_ICD_SUFFIX_KHR:
-            returnString = platform->suffix;
+            returnString = _platform->suffix;
             break;
         default:
             ret = CL_INVALID_VALUE;
@@ -163,7 +163,7 @@ done:
 
 /* Device APIs */
 CL_API_ENTRY cl_int CL_API_CALL
-clGetDeviceIDs(cl_platform_id   platform,
+clGetDeviceIDs(cl_platform_id   _platform,
                cl_device_type   device_type,
                cl_uint          num_entries,
                cl_device_id *   devices,
@@ -187,7 +187,7 @@ clGetDeviceIDs(cl_platform_id   platform,
 
 done:
     test_icd_stub_log("clGetDeviceIDs(%p, %x, %u, %p, %p)\n",
-                      platform,
+                      _platform,
                       device_type,
                       num_entries,
                       devices,
@@ -950,10 +950,10 @@ clLinkProgram(cl_context            context ,
 
 
 CL_API_ENTRY cl_int CL_API_CALL
-clUnloadPlatformCompiler(cl_platform_id  platform) CL_API_SUFFIX__VERSION_1_2
+clUnloadPlatformCompiler(cl_platform_id  _platform) CL_API_SUFFIX__VERSION_1_2
 {
     cl_int return_value = CL_OUT_OF_RESOURCES;
-    test_icd_stub_log("clUnloadPlatformCompiler(%p)\n", platform);
+    test_icd_stub_log("clUnloadPlatformCompiler(%p)\n", _platform);
     test_icd_stub_log("Value returned: %d\n", return_value);
     return return_value;
 }
@@ -1836,12 +1836,12 @@ clEnqueueNativeKernel(cl_command_queue   command_queue ,
 }
 
 CL_API_ENTRY void * CL_API_CALL
-clGetExtensionFunctionAddressForPlatform(cl_platform_id  platform ,
+clGetExtensionFunctionAddressForPlatform(cl_platform_id  _platform ,
                                          const char *    func_name) CL_API_SUFFIX__VERSION_1_2
 {
     void *return_value = (void *) malloc(sizeof(void *));
     test_icd_stub_log("clGetExtensionFunctionAddressForPlatform(%p, %p)\n",
-                      platform,
+                      _platform,
                       func_name);
 
     test_icd_stub_log("Value returned: %p\n", return_value);

--- a/test/driver_stub/cl_gl.c
+++ b/test/driver_stub/cl_gl.c
@@ -5,7 +5,7 @@
 // themselves via the dispatch table. Include this before cl headers.
 #include "rename_api.h"
 
-#define SIZE_T_MAX (size_t) 0xFFFFFFFFFFFFFFFFULL
+#include <limits.h> // SIZE_MAX
 
 CL_API_ENTRY cl_mem CL_API_CALL
 clCreateFromGLBuffer(cl_context      context ,
@@ -13,7 +13,7 @@ clCreateFromGLBuffer(cl_context      context ,
                      cl_GLuint       bufret_mem ,
                      int *           errcode_ret ) CL_API_SUFFIX__VERSION_1_0
 {    
-     cl_mem ret_mem = (cl_mem)(SIZE_T_MAX);  
+     cl_mem ret_mem = (cl_mem)(SIZE_MAX);  
      test_icd_stub_log("clCreateFromGLBuffer(%p, %x, %u, %p)\n",
                        context,
                        flags,
@@ -32,7 +32,7 @@ clCreateFromGLTexture(cl_context       context ,
                       cl_GLuint        texture ,
                       cl_int *         errcode_ret ) CL_API_SUFFIX__VERSION_1_2
 {
-     cl_mem ret_mem = (cl_mem)(SIZE_T_MAX);  
+     cl_mem ret_mem = (cl_mem)(SIZE_MAX);  
      test_icd_stub_log("clCreateFromGLTexture(%p, %x, %d, %d, %u, %p)\n",
                        context ,
                        flags ,
@@ -53,7 +53,7 @@ clCreateFromGLTexture2D(cl_context       context,
                         cl_GLuint        texture,
                         cl_int *         errcode_ret ) CL_API_SUFFIX__VERSION_1_0
 {
-     cl_mem ret_mem = (cl_mem)(SIZE_T_MAX);  
+     cl_mem ret_mem = (cl_mem)(SIZE_MAX);  
      test_icd_stub_log("clCreateFromGLTexture2D(%p, %x, %d, %d, %u, %p)\n",
                         context,
                         flags,
@@ -75,7 +75,7 @@ clCreateFromGLTexture3D(cl_context       context,
                         cl_int *         errcode_ret ) CL_API_SUFFIX__VERSION_1_0
 
 {
-     cl_mem ret_mem = (cl_mem)(SIZE_T_MAX);  
+     cl_mem ret_mem = (cl_mem)(SIZE_MAX);  
      test_icd_stub_log("clCreateFromGLTexture3D(%p, %x, %d, %d, %u, %p)\n",
                         context,
                         flags,
@@ -94,7 +94,7 @@ clCreateFromGLRenderbuffer(cl_context    context,
                            cl_GLuint     renderbuffer,
                            cl_int *      errcode_ret ) CL_API_SUFFIX__VERSION_1_0
 {
-     cl_mem ret_mem = (cl_mem)(SIZE_T_MAX);  
+     cl_mem ret_mem = (cl_mem)(SIZE_MAX);  
      test_icd_stub_log("clCreateFromGLRenderbuffer(%p, %x, %d, %p)\n",
                        context,
                        flags,
@@ -209,7 +209,7 @@ clCreateEventFromGLsyncKHR(cl_context            context ,
                            cl_int *              errcode_ret ) CL_API_SUFFIX__VERSION_1_1
 
 {
-     cl_event ret_event = (cl_event)(SIZE_T_MAX);
+     cl_event ret_event = (cl_event)(SIZE_MAX);
      test_icd_stub_log("clCreateEventFromGLsyncKHR(%p, %p, %p)\n",
                         context,
                         cl_GLsync,

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -123,7 +123,7 @@ int test_clCompileProgram(const struct clCompileProgram_st *data)
 
 int test_clLinkProgram(const struct clLinkProgram_st *data)
 {
-    cl_program program;
+    cl_program _program;
     test_icd_app_log("clLinkProgram(%p, %u, %p, %p, %u, %p, %p, %p, %p)\n",
                      context,
                      data->num_devices,
@@ -135,7 +135,7 @@ int test_clLinkProgram(const struct clLinkProgram_st *data)
                      data->user_data,
                      data->errcode_ret);
 
-    program=clLinkProgram(context,
+    _program=clLinkProgram(context,
                         data->num_devices,
                         data->device_list,
                         data->options,
@@ -145,7 +145,7 @@ int test_clLinkProgram(const struct clLinkProgram_st *data)
                         data->user_data,
                         data->errcode_ret);
 
-    test_icd_app_log("Value returned: %p\n", program);
+    test_icd_app_log("Value returned: %p\n", _program);
 
     return 0;
 

--- a/test/pkgconfig/bare/CMakeLists.txt
+++ b/test/pkgconfig/bare/CMakeLists.txt
@@ -35,7 +35,9 @@ add_test(
   COMMAND ${PROJECT_NAME}
 )
 
-set_tests_properties(${PROJECT_NAME}
-  PROPERTIES
-    ENVIRONMENT "OCL_ICD_FILENAMES=${DRIVER_STUB_PATH}"
-)
+if(DRIVER_STUB_PATH)
+  set_tests_properties(${PROJECT_NAME}
+    PROPERTIES
+      ENVIRONMENT "OCL_ICD_FILENAMES=${DRIVER_STUB_PATH}"
+  )
+endif()

--- a/test/pkgconfig/sdk/CMakeLists.txt
+++ b/test/pkgconfig/sdk/CMakeLists.txt
@@ -34,7 +34,9 @@ add_test(
   COMMAND ${PROJECT_NAME}
 )
 
-set_tests_properties(${PROJECT_NAME}
-  PROPERTIES
-    ENVIRONMENT "OCL_ICD_FILENAMES=${DRIVER_STUB_PATH}"
-)
+if(DRIVER_STUB_PATH)
+  set_tests_properties(${PROJECT_NAME}
+    PROPERTIES
+      ENVIRONMENT "OCL_ICD_FILENAMES=${DRIVER_STUB_PATH}"
+  )
+endif()


### PR DESCRIPTION
This work was born out of grievance of reproducing non-MSVC specific warnings, errors and linker failures on the OpenCL-Layers project _on Windows_ without having to fire up containers or building-installing under WSL. (At a larger scale, using Clang-derivates on Windows such as ComputeCpp often blow up the console with warnings if the device compiler sees the OpenCL headers.)

Beside touching up the source code to fix warnings, two major things were implemented in CI:
- Extend Windows CI coverage to using `clang-cl.exe`, the MSVC-like CLI of Clang.
  - This was done while porting CI definition to PowerShell and doing better error checking
  - Improving error checking uncovered a lot of shortcomings of the previous CI definition (lots of errors went unnoticed)
- Simplify Linux CI definition and accelerate it by using the same build image as the SDK does

_Note: Overall I'm fairly unsatisfied how much code getting this range of CI coverage takes. (Linux/Mac/Win, GCC/Clang/MSVC, C99/11/17, with/without lang exts, Debug/Release) CI is doing the very same thing, but with 2-3 lines of difference for every test matrix elem. I'll be thinking about how to achieve the same coverage with a unified script and much less duplication of code. I would like the scripts to be **much** simpler._