### PR TITLE
Limit calls to khrIcdInitializeTrace

### DIFF
--- a/loader/icd.c
+++ b/loader/icd.c
@@ -48,7 +48,6 @@ void khrIcdInitializeTrace(void)
 // entrypoint to initialize the ICD and add all vendors
 void khrIcdInitialize(void)
 {
-    khrIcdInitializeTrace();
     // enumerate vendors present on the system
     khrIcdOsVendorsEnumerateOnce();
 }

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -126,6 +126,9 @@ extern struct _cl_icd_dispatch khrMasterDispatch;
 // API (e.g, getPlatformIDs, etc).
 void khrIcdInitialize(void);
 
+// entrypoint to check and initialize trace.
+void khrIcdInitializeTrace(void);
+
 // go through the list of vendors (in /etc/OpenCL.conf or through 
 // the registry) and call khrIcdVendorAdd for each vendor encountered
 // n.b, this call is OS-specific

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -44,6 +44,7 @@ void khrIcdOsVendorsEnumerate(void)
     const char* vendorPath = ICD_VENDOR_PATH;
     char* envPath = NULL;
 
+    khrIcdInitializeTrace();
     khrIcdVendorsEnumerateEnv();
 
     envPath = khrIcd_secure_getenv("OCL_ICD_VENDORS");

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -113,6 +113,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
     HKEY platformsKey = NULL;
     DWORD dwIndex;
 
+    khrIcdInitializeTrace();
     khrIcdVendorsEnumerateEnv();
 
     currentStatus = khrIcdOsVendorsEnumerateDXGK();


### PR DESCRIPTION
I realized the trace initialization function was not called once, but multiple times. This moves the function to only be used once.