### PR TITLE
Prevent ICD from loading outdated amdocl binary 1.Keep track of libra…

### DIFF
--- a/loader/icd.c
+++ b/loader/icd.c
@@ -79,12 +79,28 @@ void khrIcdVendorAdd(const char *libraryName)
         goto Done;
     }
 
+    // get the library's file name
+    const char *libName = libraryName;
+    const char *c;
+    for (c = libraryName; *c; ++c)
+    {
+        if (*c == DIRECTORY_SYMBOL)
+        {
+            libName = c + 1;
+        }
+    }
+
     // ensure that we haven't already loaded this vendor
     for (vendorIterator = khrIcdVendors; vendorIterator; vendorIterator = vendorIterator->next)
     {
         if (vendorIterator->library == library)
         {
             KHR_ICD_TRACE("already loaded vendor %s, nothing to do here\n", libraryName);
+            goto Done;
+        }
+        if (!strcmp(vendorIterator->libName, libName))
+        {
+            KHR_ICD_TRACE("already loaded library %s, nothing to do here\n", libName);
             goto Done;
         }
     }
@@ -184,6 +200,8 @@ void khrIcdVendorAdd(const char *libraryName)
             KHR_ICD_TRACE("failed get platform handle to library\n");
             continue;
         }
+        vendor->libName = (char *)malloc(strlen(libName) + 1);
+        strcpy(vendor->libName, libName);
         vendor->clGetExtensionFunctionAddress = p_clGetExtensionFunctionAddress;
         vendor->platform = platforms[i];
         vendor->suffix = suffix;
@@ -417,3 +435,15 @@ void khrIcdContextPropertiesGetPlatform(const cl_context_properties *properties,
     }
 }
 
+void khrIcdFreeLibName()
+{
+    KHRicdVendor *vendorIterator;
+    for (vendorIterator = khrIcdVendors; vendorIterator; vendorIterator = vendorIterator->next)
+    {
+        if (vendorIterator->libName != NULL)
+        {
+            free(vendorIterator->libName);
+            vendorIterator->libName = NULL;
+        }
+    }
+}

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -69,6 +69,9 @@ struct KHRicdVendorRec
     // the loaded library object (true type varies on Linux versus Windows)
     void *library;
 
+    // the file name of the library
+    char *libName;
+
     // the extension suffix for this platform
     char *suffix;
 
@@ -159,6 +162,9 @@ void khrIcdOsLibraryUnload(void *library);
 void khrIcdContextPropertiesGetPlatform(
     const cl_context_properties *properties, 
     cl_platform_id *outPlatform);
+
+// free libName in KHRicdVendorRec struct
+void khrIcdFreeLibName();
 
 // internal tracing macros
 #define KHR_ICD_TRACE(...) \

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -145,6 +145,8 @@ void khrIcdOsVendorsEnumerate(void)
         closedir(dir);
     }
 
+    khrIcdFreeLibName();
+
     if (NULL != envPath)
     {
         khrIcd_free_getenv(envPath);

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -247,6 +247,9 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
     {
         KHR_ICD_TRACE("Failed to close platforms key %s, ignoring\n", platformsName);
     }
+
+    khrIcdFreeLibName();
+
 #if defined(CL_ENABLE_LAYERS)
     khrIcdLayersEnumerateEnv();
 #endif // defined(CL_ENABLE_LAYERS)


### PR DESCRIPTION
Prevent ICD from loading outdated amdocl  binary 
1.Keep track of library name in KHRicdVendorRec 
2.Check if library with the same name has already been loaded before adding it in ICD list

There are going to be two sets of amdocl in registry for ICD to load if we install a new driver on top of a previously installed old driver.
It will cause subsequent undefined behaviors such as duplicate devices.

This is because AMD driver installation switched from c-inf to u-inf which no longer uses SOFTWARE\\Khronos\\OpenCL\\Vendors. 
If a new diver is installed by either user or Windows update without manual cleanup, there will be two libraries to load according to registry.
This is not fixable from driver or installation level.

(The other vendors do not have this issue only because they haven't switched to u-inf installation yet as far as I know.)