### PR TITLE
fix an incorrect KHR_ICD_ASSERT

### DIFF
--- a/loader/icd.h
+++ b/loader/icd.h
@@ -190,7 +190,7 @@ do \
     { \
         if (!(x)) \
         { \
-            fprintf(stderr, "KHR ICD assert at %s:%d: %s failed", __FILE__, __LINE__, #x); \
+            fprintf(stderr, "KHR ICD assert at %s:%d: %s failed\n", __FILE__, __LINE__, #x); \
         } \
     } \
 } while (0)

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -183,18 +183,6 @@ do \
 #define KHR_ICD_WIDE_TRACE(...)
 #endif
 
-#define KHR_ICD_ASSERT(x) \
-do \
-{ \
-    if (khrEnableTrace) \
-    { \
-        if (!(x)) \
-        { \
-            fprintf(stderr, "KHR ICD assert at %s:%d: %s failed\n", __FILE__, __LINE__, #x); \
-        } \
-    } \
-} while (0)
-
 // if handle is NULL then return invalid_handle_error_code
 #define KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(handle,invalid_handle_error_code) \
 do \

--- a/loader/windows/icd_windows_apppackage.c
+++ b/loader/windows/icd_windows_apppackage.c
@@ -86,7 +86,7 @@ bool khrIcdOsVendorsEnumerateAppPackage(void)
     wcscat_s(dllPath, MAX_PATH, L"\\" PLATFORM_PATH L"\\OpenCLOn12.dll");
 
     char narrowDllPath[MAX_PATH];
-    WideCharToMultiByte(CP_ACP, 0, dllPath, -1, narrowDllPath, MAX_PATH, NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, dllPath, -1, narrowDllPath, MAX_PATH, NULL, NULL);
 
     ret = adapterAdd(narrowDllPath, ZeroLuid);
 

--- a/loader/windows/icd_windows_dxgk.c
+++ b/loader/windows/icd_windows_dxgk.c
@@ -44,7 +44,6 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
         LoaderEnumAdapters2 EnumAdapters;
         NTSTATUS status = STATUS_SUCCESS;
 
-        char cszLibraryName[MAX_PATH] = { 0 };
         EnumAdapters.adapter_count = 0;
         EnumAdapters.adapters = NULL;
         PFN_LoaderEnumAdapters2 pEnumAdapters2 = (PFN_LoaderEnumAdapters2)GetProcAddress(h, "D3DKMTEnumAdapters2");
@@ -146,12 +145,22 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
             }
             if (NT_SUCCESS(status) && pQueryArgs->status == LOADER_QUERY_REGISTRY_STATUS_SUCCESS)
             {
-                wchar_t* pWchar = pQueryArgs->output_string;
-                memset(cszLibraryName, 0, sizeof(cszLibraryName));
+                char cszLibraryName[MAX_PATH];
+                result = WideCharToMultiByte(
+                    CP_ACP,
+                    0,
+                    pQueryArgs->output_string,
+                    -1,
+                    cszLibraryName,
+                    MAX_PATH,
+                    NULL,
+                    NULL);
+                if (!result)
                 {
-                    size_t len;
-                    wcstombs_s(&len, cszLibraryName, sizeof(cszLibraryName), pWchar, sizeof(cszLibraryName) - 1);
-                    KHR_ICD_ASSERT(len == wcslen(pWchar) + 1);
+                    KHR_ICD_TRACE("WideCharToMultiByte status != SUCCESS\n");
+                }
+                else
+                {
                     ret |= adapterAdd(cszLibraryName, EnumAdapters.adapters[AdapterIndex].luid);
                 }
             }

--- a/loader/windows/icd_windows_dxgk.c
+++ b/loader/windows/icd_windows_dxgk.c
@@ -98,7 +98,7 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
             queryArgs.query_flags.translate_path = TRUE;
             queryArgs.value_type = REG_SZ;
             result = MultiByteToWideChar(
-                CP_ACP,
+                CP_UTF8,
                 0,
                 cszOpenCLRegKeyName,
                 szOpenCLRegKeyName,
@@ -147,7 +147,7 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
             {
                 char cszLibraryName[MAX_PATH];
                 result = WideCharToMultiByte(
-                    CP_ACP,
+                    CP_UTF8,
                     0,
                     pQueryArgs->output_string,
                     -1,

--- a/loader/windows/icd_windows_dxgk.c
+++ b/loader/windows/icd_windows_dxgk.c
@@ -150,8 +150,8 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
                 memset(cszLibraryName, 0, sizeof(cszLibraryName));
                 {
                     size_t len;
-                    wcstombs_s(&len, cszLibraryName, sizeof(cszLibraryName), pWchar, sizeof(cszLibraryName));
-                    KHR_ICD_ASSERT(len == (sizeof(cszLibraryName) - 1));
+                    wcstombs_s(&len, cszLibraryName, sizeof(cszLibraryName), pWchar, sizeof(cszLibraryName) - 1);
+                    KHR_ICD_ASSERT(len == wcslen(pWchar) + 1);
                     ret |= adapterAdd(cszLibraryName, EnumAdapters.adapters[AdapterIndex].luid);
                 }
             }


### PR DESCRIPTION
fixes #192 

* Adds a newline to the assert trace message.
* Passes the correct "count" to [wcstombs_s](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/wcstombs-s-wcstombs-s-l?view=msvc-170) - should not include the terminating NULL character.
* Changes the actual assert itself to something meaningful.