### PR TITLE
Cache Headers for CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,71 @@ name: Linux
 on: [push, pull_request]
 
 jobs:
+  headers:
+    name: Build and cache Headers
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        OS: [ubuntu-18.04, ubuntu-20.04]
+        COMPILER: [gcc]
+        EXT: [ON]
+        GEN: [Unix Makefiles]
+        CONFIG: [Release]
+        STD: [99]
+        BIN: [64]
+        CMAKE: [3.21.2]
+    env:
+      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{ matrix.CMAKE }}/cmake-${{ matrix.CMAKE }}-Linux-x86_64.tar.gz
+      CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
+      CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
+
+    steps:
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
+      with:
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - name: Checkout OpenCL-Headers
+      if: steps.headers.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: KhronosGroup/OpenCL-Headers
+        path: external/OpenCL-Headers
+
+    - name: Create Build Environment
+      run: sudo apt-get update -q;
+        if [[ "${{matrix.GEN}}" =~ "Ninja" && ! `which ninja` ]]; then sudo apt install -y ninja-build; fi;
+        sudo apt install -y ${{matrix.COMPILER}};
+        if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "gcc" ]]; then sudo apt install -y ${{matrix.COMPILER}}-multilib; fi;
+        if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "clang" ]]; then sudo apt install -y gcc-multilib ; fi;
+        mkdir -p /opt/Kitware/CMake;
+        wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
+        mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
+ 
+    - name: Build & install OpenCL-Headers
+      run: $CMAKE_EXE
+        -G "${{matrix.GEN}}"
+        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
+        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
+        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
+        -D CMAKE_C_STANDARD=${{matrix.STD}}
+        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
+        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
+        -B$GITHUB_WORKSPACE/external/OpenCL-Headers/build
+        -H$GITHUB_WORKSPACE/external/OpenCL-Headers &&
+        $CMAKE_EXE
+        --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build
+        --target install
+        --
+        -j`nproc`
+
+
   cmake-minimum:
+    needs: [headers]
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
@@ -25,11 +89,14 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
-    - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
       with:
-        repository: KhronosGroup/OpenCL-Headers
-        path: external/OpenCL-Headers
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
 
     - name: Create Build Environment
       run: sudo apt-get update -q;
@@ -41,23 +108,6 @@ jobs:
         wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
         mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
       # Install Ninja only if it's the selected generator and it's not available.
-
-    - name: Build & install OpenCL-Headers
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
-        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -B$GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        -H$GITHUB_WORKSPACE/external/OpenCL-Headers &&
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        --target install
-        --
-        -j`nproc`
 
     - name: Configure
       shell: bash
@@ -137,6 +187,7 @@ jobs:
 
 
   cmake-latest:
+    needs: [headers]
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
@@ -157,11 +208,14 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
-    - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
       with:
-        repository: KhronosGroup/OpenCL-Headers
-        path: external/OpenCL-Headers
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
 
     - name: Create Build Environment
       run: sudo apt-get update -q;
@@ -175,23 +229,6 @@ jobs:
         wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
         mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
       # Install Ninja only if it's the selected generator and it's not available.
-
-    - name: Build & install OpenCL-Headers
-      run: $CMAKE_EXE
-        -G "${{matrix.GEN}}"
-        -D CMAKE_C_FLAGS="-w -m${{matrix.BIN}}"
-        -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
-        -D CMAKE_C_STANDARD=${{matrix.STD}}
-        -D CMAKE_C_EXTENSIONS=${{matrix.EXT}}
-        -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/external/OpenCL-Headers/install
-        -B $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        -S $GITHUB_WORKSPACE/external/OpenCL-Headers;
-        $CMAKE_EXE
-        --build $GITHUB_WORKSPACE/external/OpenCL-Headers/build
-        --target install
-        --config Release
-        --
-        -j`nproc`
 
     - name: Configure
       shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,14 +22,19 @@ jobs:
       CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
 
     steps:
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
-      name: Restore Headers
+      name: Cache Headers
       id: headers
       env:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Checkout OpenCL-Headers
       if: steps.headers.outputs.cache-hit != 'true'
@@ -39,6 +44,7 @@ jobs:
         path: external/OpenCL-Headers
 
     - name: Create Build Environment
+      if: steps.headers.outputs.cache-hit != 'true'
       run: sudo apt-get update -q;
         if [[ "${{matrix.GEN}}" =~ "Ninja" && ! `which ninja` ]]; then sudo apt install -y ninja-build; fi;
         sudo apt install -y ${{matrix.COMPILER}};
@@ -49,6 +55,7 @@ jobs:
         mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
  
     - name: Build & install OpenCL-Headers
+      if: steps.headers.outputs.cache-hit != 'true'
       run: $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_BUILD_TYPE=${{matrix.CONFIG}}
@@ -89,6 +96,11 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
       name: Restore Headers
       id: headers
@@ -96,7 +108,7 @@ jobs:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Create Build Environment
       run: sudo apt-get update -q;
@@ -208,6 +220,11 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
       name: Restore Headers
       id: headers
@@ -215,7 +232,7 @@ jobs:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Create Build Environment
       run: sudo apt-get update -q;

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,14 +15,19 @@ jobs:
         STD: [11] # 90 results in errors
 
     steps:
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
-      name: Restore Headers
+      name: Cache Headers
       id: headers
       env:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Checkout OpenCL-Headers
       if: steps.headers.outputs.cache-hit != 'true'
@@ -69,6 +74,11 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
       name: Restore Headers
       id: headers
@@ -76,7 +86,7 @@ jobs:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Create Build Environment
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,33 +3,43 @@ name: MacOS
 on: [push, pull_request]
 
 jobs:
-  macos-gcc:
+
+  headers:
+    name: Build and cache Headers
     runs-on: macos-latest
     strategy:
       matrix:
-        VER: [9, 10, 11]
-        EXT: [ON, OFF]
-        GEN: [Xcode, Ninja Multi-Config]
-        STD: [99, 11] # 90 results in errors
+        VER: [11]
+        EXT: [ON]
+        GEN: [Xcode]
+        STD: [11] # 90 results in errors
 
     steps:
-    - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
+      with:
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
 
     - name: Checkout OpenCL-Headers
+      if: steps.headers.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
     - name: Create Build Environment
+      if: steps.headers.outputs.cache-hit != 'true'
       run: |
         cmake -E make_directory $GITHUB_WORKSPACE/build;
         cmake -E make_directory $GITHUB_WORKSPACE/install;
         if [[ "${{matrix.GEN}}" == "Ninja Multi-Config" && ! `which ninja` ]]; then brew install ninja; fi;
-        # Install Ninja only if it's the selected generator and it's not available.
 
     - name: Build & install OpenCL-Headers
+      if: steps.headers.outputs.cache-hit != 'true'
       run: cmake
         -G "${{matrix.GEN}}"
         -D CMAKE_C_FLAGS="-w"
@@ -44,6 +54,36 @@ jobs:
         --target install
         --config Release
         --parallel `sysctl -n hw.logicalcpu`
+
+  macos-gcc:
+    needs: [headers]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        VER: [9, 10, 11]
+        EXT: [ON, OFF]
+        GEN: [Xcode, Ninja Multi-Config]
+        STD: [99, 11] # 90 results in errors
+
+    steps:
+    - name: Checkout OpenCL-ICD-Loader
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
+      with:
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - name: Create Build Environment
+      run: |
+        cmake -E make_directory $GITHUB_WORKSPACE/build;
+        cmake -E make_directory $GITHUB_WORKSPACE/install;
+        if [[ "${{matrix.GEN}}" == "Ninja Multi-Config" && ! `which ninja` ]]; then brew install ninja; fi;
+        # Install Ninja only if it's the selected generator and it's not available.
 
     - name: Configure CMake
       # no -Werror during configuration because:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,68 @@ name: Windows
 on: [push, pull_request]
 
 jobs:
+
+  headers:
+    name: Build and cache Headers
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        VER: [v143]
+        EXT: [ON]
+        GEN: [Visual Studio 17 2022]
+        BIN: [x64]
+        STD: [17]
+        CMAKE: [3.22.0]
+    env:
+      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{matrix.CMAKE}}/cmake-${{matrix.CMAKE}}-windows-x86_64.zip
+      CMAKE_EXE: C:\Tools\Kitware\CMake\${{matrix.CMAKE}}\bin\cmake.exe
+      CTEST_EXE: C:\Tools\Kitware\CMake\${{matrix.CMAKE}}\bin\ctest.exe
+      NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
+      NINJA_EXE: C:\Tools\Ninja\ninja.exe
+
+    steps:
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
+      with:
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - name: Checkout OpenCL-Headers
+      if: steps.headers.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: KhronosGroup/OpenCL-Headers
+        path: external/OpenCL-Headers
+
+    - name: Create Build Environment
+      if: steps.headers.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        Invoke-WebRequest ${env:CMAKE_URL} -OutFile ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip
+        Expand-Archive ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip -DestinationPath C:\Tools\Kitware\CMake\
+        Rename-Item C:\Tools\Kitware\CMake\* ${{matrix.CMAKE}}
+        Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
+        Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath C:\Tools\Ninja\
+        Remove-Item ~\Downloads\*
+        & ${env:CMAKE_EXE} --version
+        & ${env:NINJA_EXE} --version
+
+
+    - name: Build & install OpenCL-Headers (MSBuild)
+      if: steps.headers.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        set C_FLAGS="/W4 /WX"
+        if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
+        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
+        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install --config Release -- /verbosity:minimal /maxCpuCount /noLogo
+
+
   msvc:
+    needs: [headers]
     runs-on: windows-2022
     strategy:
       matrix:
@@ -24,11 +85,14 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
-    - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Restore Headers
+      id: headers
+      env:
+        cache-name: cache-headers
       with:
-        repository: KhronosGroup/OpenCL-Headers
-        path: external/OpenCL-Headers
+        path: external/OpenCL-Headers/install
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
 
     - name: Create Build Environment
       shell: pwsh
@@ -41,28 +105,6 @@ jobs:
         Remove-Item ~\Downloads\*
         & ${env:CMAKE_EXE} --version
         & ${env:NINJA_EXE} --version
-
-    - name: Build & install OpenCL-Headers (MSBuild)
-      if: matrix.GEN == 'Visual Studio 17 2022'
-      shell: cmd
-      run: |
-        set C_FLAGS="/W4 /WX"
-        if /I "${{matrix.BIN}}"=="x86" (set BIN=Win32) else (set BIN=x64)
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -A %BIN% -T ${{matrix.VER}} -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install --config Release -- /verbosity:minimal /maxCpuCount /noLogo
-
-    - name: Build & install OpenCL-Headers (Ninja Multi-Config)
-      if: matrix.GEN == 'Ninja Multi-Config'
-      shell: cmd
-      run: |
-        set C_FLAGS="/W4 /WX"
-        if /I "${{matrix.VER}}"=="v140" (set VER=14.0)
-        if /I "${{matrix.VER}}"=="v141" (set VER=14.1)
-        if /I "${{matrix.VER}}"=="v142" (set VER=14.2)
-        if /I "${{matrix.VER}}"=="v143" (set VER=14.3)
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.BIN}} /vcvars_ver=%VER%
-        %CMAKE_EXE% -G "${{matrix.GEN}}" -D CMAKE_MAKE_PROGRAM=%NINJA_EXE% -D CMAKE_C_FLAGS=%C_FLAGS% -D CMAKE_C_STANDARD=${{matrix.STD}} -D CMAKE_C_EXTENSIONS=${{matrix.EXT}} -D CMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\external\OpenCL-Headers\install -S %GITHUB_WORKSPACE%\external\OpenCL-Headers -B %GITHUB_WORKSPACE%\external\OpenCL-Headers\build
-        %CMAKE_EXE% --build %GITHUB_WORKSPACE%/external/OpenCL-Headers/build --target install -- -j%NUMBER_OF_PROCESSORS%
 
     - name: Configure (MSBuild)
       if: matrix.GEN == 'Visual Studio 17 2022'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,14 +23,19 @@ jobs:
       NINJA_EXE: C:\Tools\Ninja\ninja.exe
 
     steps:
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
-      name: Restore Headers
+      name: Cache Headers
       id: headers
       env:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Checkout OpenCL-Headers
       if: steps.headers.outputs.cache-hit != 'true'
@@ -85,6 +90,11 @@ jobs:
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@v2
 
+    - name: Get sha of Headers
+      id: get-sha
+      run: |
+        echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/KhronosGroup/OpenCL-Headers/git/ref/heads/main | jq .object.sha | tr -d '"' )
+
     - uses: actions/cache@v2
       name: Restore Headers
       id: headers
@@ -92,7 +102,7 @@ jobs:
         cache-name: cache-headers
       with:
         path: external/OpenCL-Headers/install
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.get-sha.outputs.sha }}
 
     - name: Create Build Environment
       shell: pwsh


### PR DESCRIPTION
This PR caches the result of the Headers install rather than checking them out, configuring them, and rebuilding them (and their tests) for each job. The cache depends on the main last commit, and thus should be refreshed if the main branch of the Headers is updated.

This PR yields significant CI performance improvements.