### PR TITLE
fix MacOS CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
@@ -155,10 +155,10 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@3
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,8 @@ on: [push, pull_request]
 
 jobs:
   macos-gcc:
-    runs-on: macos-latest
+    #runs-on: macos-latest
+    runs-on: macos-11 # temporary, macos-latest only supports gcc-12
     strategy:
       matrix:
         VER: [9, 10, 11]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout OpenCL-ICD-Loader
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout OpenCL-Headers
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers


### PR DESCRIPTION
The GitHub actions macos-latest workflow was updated to macos-12 recently, which only has gcc-11.  Switch back to macos-11 for now at least, to unblock MacOS CI.

Also updates the checkout action to v3 to eliminate CI warnings.

edit: macos-12 only has gcc-11, not gcc-12.