### PR TITLE
Replace xml.etree.ElementTree by defusedxml.ElementTree

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,12 +6,13 @@ In order to ease maintenance and enable faster development of related OpenCL ICD
 
 ## Dependencies
 
-The API dispatch functions are generated using Python [Mako Templates](https://www.makotemplates.org/).
+The API dispatch functions are generated using Python [Mako Templates](https://www.makotemplates.org/) and [defusedxml](https://pypi.org/project/defusedxml/).
 
-In most cases, after installing Python for your platform, Mako may be installed using:
+In most cases, after installing Python for your platform, Mako and defusedxml may be installed using:
 
 ```sh
 $ pip install Mako
+$ pip install defusedxml
 ```
 
 ## Making Changes

--- a/scripts/gen/__init__.py
+++ b/scripts/gen/__init__.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 import argparse
 import sys
 import urllib
-import xml.etree.ElementTree as etree
+import defusedxml.ElementTree as etree
 import urllib.request
 
 # parse_xml - Helper function to parse the XML file from a URL or local file.


### PR DESCRIPTION
Bandit scan tool reports the following issue: Using various methods to parse untrusted XML data is known to be vulnerable to XML attacks. Should replace vulnerable imports with the equivalent defusedxml package.