### PR TITLE
Update path to pkg-config header file.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,9 @@ name: Linux
 
 on: [push, pull_request]
 
+env:
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig
+
 jobs:
   cmake-minimum:
     runs-on: ${{ matrix.OS }}
@@ -134,15 +137,15 @@ jobs:
 
     - name: Test pkg-config --cflags
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
 
     - name: Test pkg-config --libs
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" pkg-config OpenCL --libs | grep -q "\-L$GITHUB_WORKSPACE/install/lib -lOpenCL"
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --libs | grep -q "\-L$GITHUB_WORKSPACE/install/lib -lOpenCL"
 
     - name: Consume pkg-config
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" $CMAKE_EXE
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
         -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"
@@ -292,15 +295,15 @@ jobs:
 
     - name: Test pkg-config --cflags
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
 
     - name: Test pkg-config --libs
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" pkg-config OpenCL --libs | grep -q "\-L$GITHUB_WORKSPACE/install/lib -lOpenCL"
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --libs | grep -q "\-L$GITHUB_WORKSPACE/install/lib -lOpenCL"
 
     - name: Consume pkg-config
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" $CMAKE_EXE
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" $CMAKE_EXE
         -G "${{matrix.GEN}}"
         -D CMAKE_C_COMPILER=${{matrix.COMPILER}}
         -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -m${{matrix.BIN}}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux
 on: [push, pull_request]
 
 env:
-  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/share/pkgconfig
 
 jobs:
   cmake-minimum:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,9 @@ name: MacOS
 
 on: [push, pull_request]
 
+env:
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig
+
 jobs:
   macos-gcc:
     #runs-on: macos-latest
@@ -98,15 +101,15 @@ jobs:
 
     - name: Test pkg-config --cflags
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
 
     - name: Test pkg-config --libs
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" pkg-config OpenCL --libs | grep -q "\-L$GITHUB_WORKSPACE/install/lib -lOpenCL"
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --libs | grep -q "\-L$GITHUB_WORKSPACE/install/lib -lOpenCL"
 
     - name: Consume pkg-config
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig:$GITHUB_WORKSPACE/external/OpenCL-Headers/install/lib/pkgconfig" cmake
+      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" cmake
         -G "${{matrix.GEN}}"
         -D CMAKE_C_FLAGS="-Wall -Wextra -pedantic -Wno-format"
         -D CMAKE_C_COMPILER=/usr/local/bin/gcc-${{matrix.VER}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: MacOS
 on: [push, pull_request]
 
 env:
-  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/lib/pkgconfig
+  OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/share/pkgconfig
 
 jobs:
   macos-gcc:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -101,7 +101,9 @@ jobs:
 
     - name: Test pkg-config --cflags
       shell: bash
-      run: PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
+      run: |
+        if [[ ! `which pkg-config` ]]; then brew install pkg-config; fi;
+        PKG_CONFIG_PATH="$OPENCL_PKGCONFIG_PATHS" pkg-config OpenCL --cflags | grep -q "\-I$GITHUB_WORKSPACE/external/OpenCL-Headers/install/include"
 
     - name: Test pkg-config --libs
       shell: bash


### PR DESCRIPTION
This is the accompanying pull request for https://github.com/KhronosGroup/OpenCL-Headers/pull/218

The first commit refactors the way the CI handles PKG_CONFIG_PATH.
The second commit updates the path to the newly adopted path in the Headers (failure is expected until the Headers are merged).