### PR TITLE
replaces calls to LoadLibrary with explicit calls to LoadLibraryA

### DIFF
--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -273,7 +273,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
     }
 
     // Add adapters according to DXGI's preference order
-    HMODULE hDXGI = LoadLibrary("dxgi.dll");
+    HMODULE hDXGI = LoadLibraryA("dxgi.dll");
     if (hDXGI)
     {
         IDXGIFactory* pFactory = NULL;

--- a/loader/windows/icd_windows_apppackage.c
+++ b/loader/windows/icd_windows_apppackage.c
@@ -39,7 +39,7 @@ bool khrIcdOsVendorsEnumerateAppPackage(void)
     WCHAR *buffer = NULL;
     PWSTR *packages = NULL;
 
-    HMODULE h = LoadLibrary("kernel32.dll");
+    HMODULE h = LoadLibraryA("kernel32.dll");
     if (h == NULL)
         return ret;
 

--- a/loader/windows/icd_windows_dxgk.c
+++ b/loader/windows/icd_windows_dxgk.c
@@ -35,7 +35,7 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
     int result = 0;
 
     // Get handle to GDI Runtime
-    HMODULE h = LoadLibrary("gdi32.dll");
+    HMODULE h = LoadLibraryA("gdi32.dll");
     if (h == NULL)
         return ret;
 


### PR DESCRIPTION
fixes #208 

Since we're unconditionally passing an ascii string, unconditionally call LoadLibraryA instead of LoadLibrary.  This ensures that the correct function is called even if somebody compiles the OpenCL ICD loader with UNICODE support.