### PR TITLE
Update generated code to reflect recent xml updates.

### DIFF
--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -6361,7 +6361,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLBuffer(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint bufobj,
-    int* errcode_ret)
+    cl_int* errcode_ret)
 {
 #if defined(CL_ENABLE_LAYERS)
     if (khrFirstLayer)
@@ -6384,7 +6384,7 @@ static cl_mem CL_API_CALL clCreateFromGLBuffer_disp(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint bufobj,
-    int* errcode_ret)
+    cl_int* errcode_ret)
 {
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(context, CL_INVALID_CONTEXT);
     KHR_ICD_VALIDATE_POINTER_RETURN_HANDLE(context->dispatch->clCreateFromGLBuffer);

--- a/test/layer/icd_print_layer_generated.c
+++ b/test/layer/icd_print_layer_generated.c
@@ -2379,7 +2379,7 @@ static cl_mem CL_API_CALL clCreateFromGLBuffer_wrap(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint bufobj,
-    int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
 printf("clCreateFromGLBuffer\n");
 return tdispatch->clCreateFromGLBuffer(


### PR DESCRIPTION
While going through the header PR (https://github.com/KhronosGroup/OpenCL-Headers/pull/230)  I realized we hadn't regenerated the loader code since fixing some of the xml functions.

This PR addresses this discrepancy.