### PR TITLE
Add function prototype for clGetICDLoaderInfoOCLICD using function type.

### DIFF
--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -23,7 +23,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-static cl_int
+static clGetICDLoaderInfoOCLICD_t clGetICDLoaderInfoOCLICD;
+cl_int CL_API_CALL
 clGetICDLoaderInfoOCLICD(
     cl_icdl_info param_name,
     size_t       param_value_size,


### PR DESCRIPTION
This is enabled by https://github.com/KhronosGroup/OpenCL-Headers/pull/230 and displays the usefulness of the types. We were missing a `CL_API_CALL` in the clGetICDLoaderInfoOCLICD definition, which can be an issue on Windows.

This patch leverages the function type to declare the function before defining it. Forgetting the `CL_API_CALL` generates an error as can be seen here: https://github.com/Kerilk/OpenCL-ICD-Loader/actions/runs/4928441033/jobs/8806822040