### PR TITLE
CTS cache

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,28 @@ env:
   OPENCL_PKGCONFIG_PATHS: ${{ github.workspace }}/install/lib/pkgconfig:${{ github.workspace }}/external/OpenCL-Headers/install/share/pkgconfig
 
 jobs:
+
+  tools:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        CMAKE: [3.21.2]
+    env:
+      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{ matrix.CMAKE }}/cmake-${{ matrix.CMAKE }}-Linux-x86_64.tar.gz
+
+    steps:
+    - name: Cache CMake
+      uses: actions/cache@v3
+      id: cmake
+      env:
+        cache-name: cache-cmake
+      with:
+        path: ~/cmake-${{matrix.CMAKE}}-Linux-x86_64.tar.gz
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{matrix.CMAKE}}
+    - name: Checkout CMake
+      if: steps.cmake.outputs.cache-hit != 'true'
+      run: wget -c -O ~/cmake-${{matrix.CMAKE}}-Linux-x86_64.tar.gz $CMAKE_URL
+
   cmake-minimum:
     runs-on: ${{ matrix.OS }}
     container: streamhpc/opencl-sdk-base:ubuntu-18.04-20220127
@@ -154,6 +176,7 @@ jobs:
 
 
   cmake-latest:
+    needs: [tools]
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
@@ -165,7 +188,6 @@ jobs:
         BIN: [32, 64]
         CMAKE: [3.21.2]
     env:
-      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{ matrix.CMAKE }}/cmake-${{ matrix.CMAKE }}-Linux-x86_64.tar.gz
       CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
       CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
 
@@ -180,6 +202,15 @@ jobs:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
+    - name: Restore CMake
+      uses: actions/cache@v3
+      id: cmake
+      env:
+        cache-name: cache-cmake
+      with:
+        path: ~/cmake-${{matrix.CMAKE}}-Linux-x86_64.tar.gz
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{matrix.CMAKE}}
+
     - name: Create Build Environment
       run: sudo apt-get update -q;
         if [[ "${{matrix.GEN}}" =~ "Ninja" && ! `which ninja` ]]; then sudo apt install -y ninja-build; fi;
@@ -189,7 +220,7 @@ jobs:
         if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "gcc" ]]; then sudo apt install -y ${{matrix.COMPILER}}-multilib; fi;
         if [[ "${{matrix.BIN}}" == "32" && "${{matrix.COMPILER}}" =~ "clang" ]]; then sudo apt install -y gcc-multilib ; fi;
         mkdir -p /opt/Kitware/CMake;
-        wget -c $CMAKE_URL -O - | tar -xz --directory /opt/Kitware/CMake;
+        tar -xzf ~/cmake-${{matrix.CMAKE}}-Linux-x86_64.tar.gz --directory /opt/Kitware/CMake;
         mv /opt/Kitware/CMake/cmake-${{ matrix.CMAKE }}-* /opt/Kitware/CMake/${{ matrix.CMAKE }}
       # Install Ninja only if it's the selected generator and it's not available.
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,45 @@ name: Windows
 on: [push, pull_request]
 
 jobs:
+
+  tools:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        CMAKE: [3.22.0]
+        NINJA: [1.10.2]
+    env:
+      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{matrix.CMAKE}}/cmake-${{matrix.CMAKE}}-windows-x86_64.zip
+      NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v${{matrix.NINJA}}/ninja-win.zip
+
+    steps:
+    - name: Cache CMake
+      uses: actions/cache@v3
+      id: cmake
+      env:
+        cache-name: cache-cmake
+      with:
+        path: ~/Downloads/cmake-${{matrix.CMAKE}}-windows-x86_64.zip
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{matrix.CMAKE}}
+    - name: Cache Ninja
+      uses: actions/cache@v3
+      id: ninja
+      env:
+        cache-name: cache-ninja
+      with:
+        path: ~/Downloads/ninja-win.zip
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{matrix.NINJA}}
+    - name: Checkout CMake
+      if: steps.cmake.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: Invoke-WebRequest ${env:CMAKE_URL} -OutFile ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip
+    - name: Checkout Ninja
+      if: steps.ninja.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
+
   msvc:
+    needs: [tools]
     runs-on: windows-2022
     strategy:
       matrix:
@@ -13,11 +51,10 @@ jobs:
         BIN: [x64, x86]
         STD: [90, 11, 17]
         CMAKE: [3.22.0]
+        NINJA: [1.10.2]
     env:
-      CMAKE_URL: https://github.com/Kitware/CMake/releases/download/v${{matrix.CMAKE}}/cmake-${{matrix.CMAKE}}-windows-x86_64.zip
       CMAKE_EXE: C:\Tools\Kitware\CMake\${{matrix.CMAKE}}\bin\cmake.exe
       CTEST_EXE: C:\Tools\Kitware\CMake\${{matrix.CMAKE}}\bin\ctest.exe
-      NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
       NINJA_EXE: C:\Tools\Ninja\ninja.exe
 
     steps:
@@ -30,15 +67,30 @@ jobs:
         repository: KhronosGroup/OpenCL-Headers
         path: external/OpenCL-Headers
 
+    - name: Restore CMake
+      uses: actions/cache@v3
+      id: cmake
+      env:
+        cache-name: cache-cmake
+      with:
+        path: ~/Downloads/cmake-${{matrix.CMAKE}}-windows-x86_64.zip
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{matrix.CMAKE}}
+
+    - name: Restore Ninja
+      uses: actions/cache@v3
+      id: ninja
+      env:
+        cache-name: cache-ninja
+      with:
+        path: ~/Downloads/ninja-win.zip
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{matrix.NINJA}}
+
     - name: Create Build Environment
       shell: pwsh
       run: |
-        Invoke-WebRequest ${env:CMAKE_URL} -OutFile ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip
         Expand-Archive ~\Downloads\cmake-${{matrix.CMAKE}}-windows-x86_64.zip -DestinationPath C:\Tools\Kitware\CMake\
         Rename-Item C:\Tools\Kitware\CMake\* ${{matrix.CMAKE}}
-        Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
         Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath C:\Tools\Ninja\
-        Remove-Item ~\Downloads\*
         & ${env:CMAKE_EXE} --version
         & ${env:NINJA_EXE} --version
 


### PR DESCRIPTION
This implements my suggestion from today. This may not fully resolve the issue but alleviate it greatly. It ensures some external dependencies are cached before the jobs are started. If this is an improvement, we could generalize to other platforms. 

There also exist ways to cache deb packages on Ubuntu to avoid having to re-download them each times:
```
      - uses: awalsh128/cache-apt-pkgs-action@latest
        with:
          packages: 
          version: 1.0
```
We could think about adopting these as well.