### PR TITLE
add const to fix compiler warnings

### DIFF
--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -132,7 +132,8 @@ static int compareDirElem(const void *a, const void *b)
     return strcoll(((struct dirElem *)a)->d_name, ((struct dirElem *)b)->d_name);
 }
 
-static inline void khrIcdOsDirEnumerate(char *path, char *env, const char *extension,
+static inline void khrIcdOsDirEnumerate(const char *path, const char *env,
+                                        const char *extension,
                                         khrIcdFileAdd addFunc, int bSort)
 {
     DIR *dir = NULL;


### PR DESCRIPTION
Fix a few warnings due to missing `const`:

```sh
icd_platform.h:30:25: warning: passing argument 1 of ‘khrIcdOsDirEnumerate’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   30 | #define ICD_VENDOR_PATH "/etc/OpenCL/vendors"
      |                         ^~~~~~~~~~~~~~~~~~~~~
icd_linux.c:219:26: note: in expansion of macro ‘ICD_VENDOR_PATH’
  219 |     khrIcdOsDirEnumerate(ICD_VENDOR_PATH, "OCL_ICD_VENDORS", ".icd", khrIcdVendorAdd, 0);
      |                          ^~~~~~~~~~~~~~~
...
icd_linux.c:219:43: warning: passing argument 2 of ‘khrIcdOsDirEnumerate’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  219 |     khrIcdOsDirEnumerate(ICD_VENDOR_PATH, "OCL_ICD_VENDORS", ".icd", khrIcdVendorAdd, 0);
      |                                           ^~~~~~~~~~~~~~~~~
```