### PR TITLE
WIP: add an OpenCL ICD loader extension to shut down and free memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,31 @@ if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR OPENCL_ICD_LOADER_BUILD_TESTING)
     add_subdirectory (test)
 endif()
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    find_package(Python3 COMPONENTS Interpreter)
+    set(OPENCL_ICD_LOADER_XML_PATH CACHE FILEPATH "Path to cl.xml for OpenCL ICD Loader code generation")
+    set(OPENCL_ICD_LOADER_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
+    add_custom_target(icd_loader_generate
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}
+        COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+            ${Python3_EXECUTABLE} gen_loader.py
+            -registry ${OPENCL_ICD_LOADER_XML_PATH}
+            -o ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}
+        COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+            ${Python3_EXECUTABLE} gen_print_layer.py
+            -registry ${OPENCL_ICD_LOADER_XML_PATH}
+            -o ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}
+    )
+    add_custom_target(icd_loader_loader_copy
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}/icd_dispatch_generated.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/loader
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}/icd_print_layer_generated.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/layer
+    )
+endif()
+
 include (GNUInstallDirs)
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
             -registry ${OPENCL_ICD_LOADER_XML_PATH}
             -o ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}
     )
-    add_custom_target(icd_loader_loader_copy
+    add_custom_target(icd_loader_copy
         COMMAND ${CMAKE_COMMAND} -E copy
             ${OPENCL_ICD_LOADER_OUTPUT_DIRECTORY}/icd_dispatch_generated.c
             ${CMAKE_CURRENT_SOURCE_DIR}/loader

--- a/loader/icd.c
+++ b/loader/icd.c
@@ -303,10 +303,10 @@ void khrIcdLayerAdd(const char *libraryName)
     if (khrFirstLayer) {
         targetDispatch = &(khrFirstLayer->dispatch);
     } else {
-        targetDispatch = &khrMasterDispatch;
+        targetDispatch = &khrActualDispatch;
     }
 
-    loaderDispatchNumEntries = sizeof(khrMasterDispatch)/sizeof(void*);
+    loaderDispatchNumEntries = sizeof(khrActualDispatch)/sizeof(void*);
     result = p_clInitLayer(
         loaderDispatchNumEntries,
         targetDispatch,

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -117,7 +117,7 @@ struct KHRLayer
 #ifdef CL_LAYER_INFO
     // The layer library name
     char *libraryName;
-    // the pointer to the clGetLayerInfo funciton
+    // the pointer to the clGetLayerInfo function
     void *p_clGetLayerInfo;
 #endif
 };
@@ -174,6 +174,8 @@ void khrIcdOsLibraryUnload(void *library);
 void khrIcdContextPropertiesGetPlatform(
     const cl_context_properties *properties, 
     cl_platform_id *outPlatform);
+
+void khrIcdShutdown(void);
 
 // internal tracing macros
 #define KHR_ICD_TRACE(...) \

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -124,7 +124,7 @@ struct KHRLayer
 
 // the global layer state
 extern struct KHRLayer * khrFirstLayer;
-extern struct _cl_icd_dispatch khrMasterDispatch;
+extern struct _cl_icd_dispatch khrActualDispatch;
 #endif // defined(CL_ENABLE_LAYERS)
 
 /* 

--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -65,6 +65,13 @@ clGetICDLoaderInfoOCLICD(
     return CL_SUCCESS;
 }
 
+// !!! TODO: Switch this to use the function typedef when it's in the headers!
+static cl_int CL_API_CALL clShutdownOCLICD(void)
+{
+    khrIcdShutdown();
+    return CL_SUCCESS;
+}
+
 static void* khrIcdGetExtensionFunctionAddress(const char* function_name)
 {
 // Most extensions, including multi-vendor KHR and EXT extensions,
@@ -138,6 +145,9 @@ static void* khrIcdGetExtensionFunctionAddress(const char* function_name)
 
     // cl_icdl
     KHR_ICD_CHECK_EXTENSION_FUNCTION(clGetICDLoaderInfoOCLICD);
+
+    // cl_icd_shutdown
+    KHR_ICD_CHECK_EXTENSION_FUNCTION(clShutdownOCLICD);
 
 #undef KHR_ICD_CHECK_EXTENSION_FUNCTION
 

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -8169,7 +8169,7 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_disp(
 ///////////////////////////////////////////////////////////////////////////////
 
 #if defined(CL_ENABLE_LAYERS)
-struct _cl_icd_dispatch khrMasterDispatch = {
+struct _cl_icd_dispatch khrActualDispatch = {
     &clGetPlatformIDs_disp,
     &clGetPlatformInfo_disp,
     &clGetDeviceIDs_disp,

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -24,13 +24,15 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-// Core APIs:
+
 #if defined(CL_ENABLE_LAYERS)
 extern cl_int CL_API_CALL clGetPlatformIDs_disp(
     cl_uint num_entries,
     cl_platform_id* platforms,
     cl_uint* num_platforms) CL_API_SUFFIX__VERSION_1_0;
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetPlatformInfo(
     cl_platform_id platform,
@@ -57,7 +59,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetPlatformInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetPlatformInfo_disp(
     cl_platform_id platform,
@@ -103,7 +104,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDs(
         num_devices);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetDeviceIDs_disp(
     cl_platform_id platform,
@@ -149,7 +149,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetDeviceInfo_disp(
     cl_device_id device,
@@ -201,7 +200,6 @@ CL_API_ENTRY cl_context CL_API_CALL clCreateContext(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_context CL_API_CALL clCreateContext_disp(
     const cl_context_properties* properties,
@@ -255,7 +253,6 @@ CL_API_ENTRY cl_context CL_API_CALL clCreateContextFromType(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_context CL_API_CALL clCreateContextFromType_disp(
     const cl_context_properties* properties,
@@ -292,7 +289,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainContext(
         context);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainContext_disp(
     cl_context context)
@@ -318,7 +314,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseContext(
         context);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseContext_disp(
     cl_context context)
@@ -356,7 +351,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetContextInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetContextInfo_disp(
     cl_context context,
@@ -390,7 +384,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainCommandQueue(
         command_queue);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainCommandQueue_disp(
     cl_command_queue command_queue)
@@ -416,7 +409,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseCommandQueue(
         command_queue);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseCommandQueue_disp(
     cl_command_queue command_queue)
@@ -454,7 +446,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetCommandQueueInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetCommandQueueInfo_disp(
     cl_command_queue command_queue,
@@ -500,7 +491,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBuffer(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateBuffer_disp(
     cl_context context,
@@ -534,7 +524,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainMemObject(
         memobj);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainMemObject_disp(
     cl_mem memobj)
@@ -560,7 +549,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseMemObject(
         memobj);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseMemObject_disp(
     cl_mem memobj)
@@ -601,7 +589,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetSupportedImageFormats(
         num_image_formats);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetSupportedImageFormats_disp(
     cl_context context,
@@ -649,7 +636,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemObjectInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetMemObjectInfo_disp(
     cl_mem memobj,
@@ -695,7 +681,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetImageInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetImageInfo_disp(
     cl_mem image,
@@ -729,7 +714,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainSampler(
         sampler);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainSampler_disp(
     cl_sampler sampler)
@@ -755,7 +739,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseSampler(
         sampler);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseSampler_disp(
     cl_sampler sampler)
@@ -793,7 +776,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetSamplerInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetSamplerInfo_disp(
     cl_sampler sampler,
@@ -839,7 +821,6 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithSource(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_program CL_API_CALL clCreateProgramWithSource_disp(
     cl_context context,
@@ -891,7 +872,6 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBinary(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_program CL_API_CALL clCreateProgramWithBinary_disp(
     cl_context context,
@@ -929,7 +909,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainProgram(
         program);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainProgram_disp(
     cl_program program)
@@ -955,7 +934,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseProgram(
         program);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseProgram_disp(
     cl_program program)
@@ -996,7 +974,6 @@ CL_API_ENTRY cl_int CL_API_CALL clBuildProgram(
         user_data);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clBuildProgram_disp(
     cl_program program,
@@ -1044,7 +1021,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetProgramInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetProgramInfo_disp(
     cl_program program,
@@ -1093,7 +1069,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetProgramBuildInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetProgramBuildInfo_disp(
     cl_program program,
@@ -1135,7 +1110,6 @@ CL_API_ENTRY cl_kernel CL_API_CALL clCreateKernel(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_kernel CL_API_CALL clCreateKernel_disp(
     cl_program program,
@@ -1174,7 +1148,6 @@ CL_API_ENTRY cl_int CL_API_CALL clCreateKernelsInProgram(
         num_kernels_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clCreateKernelsInProgram_disp(
     cl_program program,
@@ -1206,7 +1179,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainKernel(
         kernel);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainKernel_disp(
     cl_kernel kernel)
@@ -1232,7 +1204,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseKernel(
         kernel);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseKernel_disp(
     cl_kernel kernel)
@@ -1267,7 +1238,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArg(
         arg_value);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetKernelArg_disp(
     cl_kernel kernel,
@@ -1311,7 +1281,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetKernelInfo_disp(
     cl_kernel kernel,
@@ -1360,7 +1329,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelWorkGroupInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetKernelWorkGroupInfo_disp(
     cl_kernel kernel,
@@ -1402,7 +1370,6 @@ CL_API_ENTRY cl_int CL_API_CALL clWaitForEvents(
         event_list);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clWaitForEvents_disp(
     cl_uint num_events,
@@ -1445,7 +1412,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetEventInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetEventInfo_disp(
     cl_event event,
@@ -1479,7 +1445,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainEvent(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainEvent_disp(
     cl_event event)
@@ -1505,7 +1470,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseEvent(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseEvent_disp(
     cl_event event)
@@ -1543,7 +1507,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetEventProfilingInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetEventProfilingInfo_disp(
     cl_event event,
@@ -1577,7 +1540,6 @@ CL_API_ENTRY cl_int CL_API_CALL clFlush(
         command_queue);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clFlush_disp(
     cl_command_queue command_queue)
@@ -1603,7 +1565,6 @@ CL_API_ENTRY cl_int CL_API_CALL clFinish(
         command_queue);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clFinish_disp(
     cl_command_queue command_queue)
@@ -1653,7 +1614,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadBuffer(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReadBuffer_disp(
     cl_command_queue command_queue,
@@ -1719,7 +1679,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBuffer(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueWriteBuffer_disp(
     cl_command_queue command_queue,
@@ -1785,7 +1744,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBuffer(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueCopyBuffer_disp(
     cl_command_queue command_queue,
@@ -1857,7 +1815,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadImage(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReadImage_disp(
     cl_command_queue command_queue,
@@ -1933,7 +1890,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteImage(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueWriteImage_disp(
     cl_command_queue command_queue,
@@ -2003,7 +1959,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImage(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueCopyImage_disp(
     cl_command_queue command_queue,
@@ -2069,7 +2024,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImageToBuffer(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueCopyImageToBuffer_disp(
     cl_command_queue command_queue,
@@ -2135,7 +2089,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferToImage(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueCopyBufferToImage_disp(
     cl_command_queue command_queue,
@@ -2204,7 +2157,6 @@ CL_API_ENTRY void* CL_API_CALL clEnqueueMapBuffer(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static void* CL_API_CALL clEnqueueMapBuffer_disp(
     cl_command_queue command_queue,
@@ -2281,7 +2233,6 @@ CL_API_ENTRY void* CL_API_CALL clEnqueueMapImage(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static void* CL_API_CALL clEnqueueMapImage_disp(
     cl_command_queue command_queue,
@@ -2344,7 +2295,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueUnmapMemObject(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueUnmapMemObject_disp(
     cl_command_queue command_queue,
@@ -2404,7 +2354,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueNDRangeKernel(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueNDRangeKernel_disp(
     cl_command_queue command_queue,
@@ -2473,7 +2422,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueNativeKernel(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueNativeKernel_disp(
     cl_command_queue command_queue,
@@ -2526,7 +2474,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetCommandQueueProperty(
         old_properties);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetCommandQueueProperty_disp(
     cl_command_queue command_queue,
@@ -2579,7 +2526,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImage2D(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateImage2D_disp(
     cl_context context,
@@ -2646,7 +2592,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImage3D(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateImage3D_disp(
     cl_context context,
@@ -2693,7 +2638,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarker(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueMarker_disp(
     cl_command_queue command_queue,
@@ -2727,7 +2671,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWaitForEvents(
         event_list);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueWaitForEvents_disp(
     cl_command_queue command_queue,
@@ -2757,7 +2700,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrier(
         command_queue);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueBarrier_disp(
     cl_command_queue command_queue)
@@ -2782,7 +2724,6 @@ CL_API_ENTRY cl_int CL_API_CALL clUnloadCompiler(
     return CL_SUCCESS;
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clUnloadCompiler_disp(
     void )
@@ -2793,10 +2734,13 @@ static cl_int CL_API_CALL clUnloadCompiler_disp(
 #endif // defined(CL_ENABLE_LAYERS)
 
 ///////////////////////////////////////////////////////////////////////////////
+
 #if defined(CL_ENABLE_LAYERS)
 extern void* CL_API_CALL clGetExtensionFunctionAddress_disp(
     const char* func_name) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueue(
     cl_context context,
@@ -2820,7 +2764,6 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueue(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_command_queue CL_API_CALL clCreateCommandQueue_disp(
     cl_context context,
@@ -2864,7 +2807,6 @@ CL_API_ENTRY cl_sampler CL_API_CALL clCreateSampler(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_sampler CL_API_CALL clCreateSampler_disp(
     cl_context context,
@@ -2910,7 +2852,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueTask(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueTask_disp(
     cl_command_queue command_queue,
@@ -2956,7 +2897,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateSubBuffer(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateSubBuffer_disp(
     cl_mem buffer,
@@ -2996,7 +2936,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorCallback(
         user_data);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetMemObjectDestructorCallback_disp(
     cl_mem memobj,
@@ -3029,7 +2968,6 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateUserEvent(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_event CL_API_CALL clCreateUserEvent_disp(
     cl_context context,
@@ -3060,7 +2998,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetUserEventStatus(
         execution_status);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetUserEventStatus_disp(
     cl_event event,
@@ -3097,7 +3034,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetEventCallback(
         user_data);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetEventCallback_disp(
     cl_event event,
@@ -3168,7 +3104,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadBufferRect(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReadBufferRect_disp(
     cl_command_queue command_queue,
@@ -3259,7 +3194,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBufferRect(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueWriteBufferRect_disp(
     cl_command_queue command_queue,
@@ -3347,7 +3281,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferRect(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueCopyBufferRect_disp(
     cl_command_queue command_queue,
@@ -3409,7 +3342,6 @@ CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevices(
         num_devices_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clCreateSubDevices_disp(
     cl_device_id in_device,
@@ -3443,7 +3375,6 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainDevice(
         device);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainDevice_disp(
     cl_device_id device)
@@ -3469,7 +3400,6 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseDevice(
         device);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseDevice_disp(
     cl_device_id device)
@@ -3510,7 +3440,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImage(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateImage_disp(
     cl_context context,
@@ -3558,7 +3487,6 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBuiltInKernels(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_program CL_API_CALL clCreateProgramWithBuiltInKernels_disp(
     cl_context context,
@@ -3616,7 +3544,6 @@ CL_API_ENTRY cl_int CL_API_CALL clCompileProgram(
         user_data);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clCompileProgram_disp(
     cl_program program,
@@ -3682,7 +3609,6 @@ CL_API_ENTRY cl_program CL_API_CALL clLinkProgram(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_program CL_API_CALL clLinkProgram_disp(
     cl_context context,
@@ -3724,7 +3650,6 @@ CL_API_ENTRY cl_int CL_API_CALL clUnloadPlatformCompiler(
         platform);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clUnloadPlatformCompiler_disp(
     cl_platform_id platform)
@@ -3765,7 +3690,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelArgInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetKernelArgInfo_disp(
     cl_kernel kernel,
@@ -3825,7 +3749,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillBuffer(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueFillBuffer_disp(
     cl_command_queue command_queue,
@@ -3888,7 +3811,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillImage(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueFillImage_disp(
     cl_command_queue command_queue,
@@ -3946,7 +3868,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemObjects(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueMigrateMemObjects_disp(
     cl_command_queue command_queue,
@@ -3993,7 +3914,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarkerWithWaitList(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueMarkerWithWaitList_disp(
     cl_command_queue command_queue,
@@ -4034,7 +3954,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrierWithWaitList(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueBarrierWithWaitList_disp(
     cl_command_queue command_queue,
@@ -4052,11 +3971,14 @@ static cl_int CL_API_CALL clEnqueueBarrierWithWaitList_disp(
 #endif // defined(CL_ENABLE_LAYERS)
 
 ///////////////////////////////////////////////////////////////////////////////
+
 #if defined(CL_ENABLE_LAYERS)
 extern void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_disp(
     cl_platform_id platform,
     const char* func_name) CL_API_SUFFIX__VERSION_1_2;
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties(
     cl_context context,
@@ -4080,7 +4002,6 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties_disp(
     cl_context context,
@@ -4127,7 +4048,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreatePipe(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreatePipe_disp(
     cl_context context,
@@ -4175,7 +4095,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetPipeInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetPipeInfo_disp(
     cl_mem pipe,
@@ -4218,7 +4137,6 @@ CL_API_ENTRY void* CL_API_CALL clSVMAlloc(
         alignment);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static void* CL_API_CALL clSVMAlloc_disp(
     cl_context context,
@@ -4256,7 +4174,6 @@ CL_API_ENTRY void CL_API_CALL clSVMFree(
         svm_pointer);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static void CL_API_CALL clSVMFree_disp(
     cl_context context,
@@ -4290,7 +4207,6 @@ CL_API_ENTRY cl_sampler CL_API_CALL clCreateSamplerWithProperties(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_sampler CL_API_CALL clCreateSamplerWithProperties_disp(
     cl_context context,
@@ -4326,7 +4242,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer(
         arg_value);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetKernelArgSVMPointer_disp(
     cl_kernel kernel,
@@ -4365,7 +4280,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelExecInfo(
         param_value);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetKernelExecInfo_disp(
     cl_kernel kernel,
@@ -4418,7 +4332,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMFree(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueSVMFree_disp(
     cl_command_queue command_queue,
@@ -4479,7 +4392,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemcpy(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueSVMMemcpy_disp(
     cl_command_queue command_queue,
@@ -4540,7 +4452,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemFill(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueSVMMemFill_disp(
     cl_command_queue command_queue,
@@ -4601,7 +4512,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMap(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueSVMMap_disp(
     cl_command_queue command_queue,
@@ -4653,7 +4563,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMUnmap(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueSVMUnmap_disp(
     cl_command_queue command_queue,
@@ -4693,7 +4602,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetDefaultDeviceCommandQueue(
         command_queue);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetDefaultDeviceCommandQueue_disp(
     cl_context context,
@@ -4729,7 +4637,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceAndHostTimer(
         host_timestamp);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetDeviceAndHostTimer_disp(
     cl_device_id device,
@@ -4762,7 +4669,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetHostTimer(
         host_timestamp);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetHostTimer_disp(
     cl_device_id device,
@@ -4799,7 +4705,6 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithIL(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_program CL_API_CALL clCreateProgramWithIL_disp(
     cl_context context,
@@ -4834,7 +4739,6 @@ CL_API_ENTRY cl_kernel CL_API_CALL clCloneKernel(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_kernel CL_API_CALL clCloneKernel_disp(
     cl_kernel source_kernel,
@@ -4883,7 +4787,6 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfo(
         param_value_size_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetKernelSubGroupInfo_disp(
     cl_kernel kernel,
@@ -4944,7 +4847,6 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMigrateMem(
         event);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueSVMMigrateMem_disp(
     cl_command_queue command_queue,
@@ -4993,7 +4895,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetProgramSpecializationConstant(
         spec_value);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetProgramSpecializationConstant_disp(
     cl_program program,
@@ -5031,7 +4932,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetProgramReleaseCallback(
         user_data);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetProgramReleaseCallback_disp(
     cl_program program,
@@ -5067,7 +4967,6 @@ CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback(
         user_data);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clSetContextDestructorCallback_disp(
     cl_context context,
@@ -5112,7 +5011,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferWithProperties(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateBufferWithProperties_disp(
     cl_context context,
@@ -5166,7 +5064,6 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateImageWithProperties(
         errcode_ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateImageWithProperties_disp(
     cl_context context,
@@ -5189,8 +5086,9 @@ static cl_mem CL_API_CALL clCreateImageWithProperties_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
-///////////////////////////////////////////////////////////////////////////////
 
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_ext_device_fission
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseDeviceEXT(
@@ -5206,6 +5104,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseDeviceEXT(
     return device->dispatch->clReleaseDeviceEXT(
         device);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clReleaseDeviceEXT_disp(
     cl_device_id device)
@@ -5216,6 +5115,9 @@ static cl_int CL_API_CALL clReleaseDeviceEXT_disp(
         device);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_ext_device_fission
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainDeviceEXT(
     cl_device_id device)
@@ -5230,6 +5132,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainDeviceEXT(
     return device->dispatch->clRetainDeviceEXT(
         device);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clRetainDeviceEXT_disp(
     cl_device_id device)
@@ -5240,6 +5143,9 @@ static cl_int CL_API_CALL clRetainDeviceEXT_disp(
         device);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_ext_device_fission
 
 CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevicesEXT(
     cl_device_id in_device,
@@ -5266,6 +5172,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevicesEXT(
         out_devices,
         num_devices);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clCreateSubDevicesEXT_disp(
     cl_device_id in_device,
@@ -5285,11 +5192,11 @@ static cl_int CL_API_CALL clCreateSubDevicesEXT_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
-///////////////////////////////////////////////////////////////////////////////
-
-// cl_khr_d3d10_sharing
 
 #if defined(_WIN32)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
     cl_platform_id platform,
@@ -5322,6 +5229,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
         devices,
         num_devices);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR_disp(
     cl_platform_id platform,
@@ -5345,6 +5253,9 @@ static cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
+
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
     cl_context context,
     cl_mem_flags flags,
@@ -5367,6 +5278,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
         resource,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromD3D10BufferKHR_disp(
     cl_context context,
@@ -5383,6 +5295,9 @@ static cl_mem CL_API_CALL clCreateFromD3D10BufferKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
     cl_context context,
@@ -5409,6 +5324,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
         subresource,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR_disp(
     cl_context context,
@@ -5427,6 +5343,9 @@ static cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
     cl_context context,
@@ -5453,6 +5372,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
         subresource,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR_disp(
     cl_context context,
@@ -5471,6 +5391,9 @@ static cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
     cl_command_queue command_queue,
@@ -5500,6 +5423,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR_disp(
     cl_command_queue command_queue,
@@ -5520,6 +5444,9 @@ static cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR_disp(
         event);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
     cl_command_queue command_queue,
@@ -5549,6 +5476,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR_disp(
     cl_command_queue command_queue,
@@ -5572,11 +5500,10 @@ static cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR_disp(
 
 #endif // defined(_WIN32)
 
-///////////////////////////////////////////////////////////////////////////////
-
-// cl_khr_d3d11_sharing
-
 #if defined(_WIN32)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
     cl_platform_id platform,
@@ -5609,6 +5536,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
         devices,
         num_devices);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR_disp(
     cl_platform_id platform,
@@ -5632,6 +5560,9 @@ static cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
+
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
     cl_context context,
     cl_mem_flags flags,
@@ -5654,6 +5585,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
         resource,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromD3D11BufferKHR_disp(
     cl_context context,
@@ -5670,6 +5602,9 @@ static cl_mem CL_API_CALL clCreateFromD3D11BufferKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
     cl_context context,
@@ -5696,6 +5631,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
         subresource,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR_disp(
     cl_context context,
@@ -5714,6 +5650,9 @@ static cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
     cl_context context,
@@ -5740,6 +5679,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
         subresource,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR_disp(
     cl_context context,
@@ -5758,6 +5698,9 @@ static cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
     cl_command_queue command_queue,
@@ -5787,6 +5730,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR_disp(
     cl_command_queue command_queue,
@@ -5807,6 +5751,9 @@ static cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR_disp(
         event);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
     cl_command_queue command_queue,
@@ -5836,6 +5783,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR_disp(
     cl_command_queue command_queue,
@@ -5859,11 +5807,10 @@ static cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR_disp(
 
 #endif // defined(_WIN32)
 
-///////////////////////////////////////////////////////////////////////////////
-
-// cl_khr_dx9_media_sharing
-
 #if defined(_WIN32)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_dx9_media_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
     cl_platform_id platform,
@@ -5899,6 +5846,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
         devices,
         num_devices);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR_disp(
     cl_platform_id platform,
@@ -5923,6 +5871,9 @@ static cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR_disp(
         num_devices);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_dx9_media_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
     cl_context context,
@@ -5952,6 +5903,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
         plane,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR_disp(
     cl_context context,
@@ -5972,6 +5924,9 @@ static cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_dx9_media_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
     cl_command_queue command_queue,
@@ -6001,6 +5956,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR_disp(
     cl_command_queue command_queue,
@@ -6021,6 +5977,9 @@ static cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR_disp(
         event);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_dx9_media_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
     cl_command_queue command_queue,
@@ -6050,6 +6009,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR_disp(
     cl_command_queue command_queue,
@@ -6074,7 +6034,6 @@ static cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR_disp(
 #endif // defined(_WIN32)
 
 ///////////////////////////////////////////////////////////////////////////////
-
 // cl_khr_egl_event
 
 CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromEGLSyncKHR(
@@ -6099,6 +6058,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromEGLSyncKHR(
         display,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_event CL_API_CALL clCreateEventFromEGLSyncKHR_disp(
     cl_context context,
@@ -6116,8 +6076,8 @@ static cl_event CL_API_CALL clCreateEventFromEGLSyncKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
-///////////////////////////////////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_egl_image
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromEGLImageKHR(
@@ -6148,6 +6108,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromEGLImageKHR(
         properties,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromEGLImageKHR_disp(
     cl_context context,
@@ -6168,6 +6129,9 @@ static cl_mem CL_API_CALL clCreateFromEGLImageKHR_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_egl_image
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR(
     cl_command_queue command_queue,
@@ -6197,6 +6161,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR_disp(
     cl_command_queue command_queue,
@@ -6217,6 +6182,9 @@ static cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR_disp(
         event);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_egl_image
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR(
     cl_command_queue command_queue,
@@ -6246,6 +6214,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_disp(
     cl_command_queue command_queue,
@@ -6267,8 +6236,8 @@ static cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
-///////////////////////////////////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_event
 
 CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
@@ -6290,6 +6259,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
         sync,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_event CL_API_CALL clCreateEventFromGLsyncKHR_disp(
     cl_context context,
@@ -6305,8 +6275,8 @@ static cl_event CL_API_CALL clCreateEventFromGLsyncKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
-///////////////////////////////////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
@@ -6336,6 +6306,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
         param_value,
         param_value_size_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetGLContextInfoKHR_disp(
     const cl_context_properties* properties,
@@ -6356,6 +6327,9 @@ static cl_int CL_API_CALL clGetGLContextInfoKHR_disp(
         param_value_size_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLBuffer(
     cl_context context,
@@ -6379,6 +6353,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLBuffer(
         bufobj,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromGLBuffer_disp(
     cl_context context,
@@ -6395,6 +6370,9 @@ static cl_mem CL_API_CALL clCreateFromGLBuffer_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture(
     cl_context context,
@@ -6424,6 +6402,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture(
         texture,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromGLTexture_disp(
     cl_context context,
@@ -6444,6 +6423,9 @@ static cl_mem CL_API_CALL clCreateFromGLTexture_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer(
     cl_context context,
@@ -6467,6 +6449,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLRenderbuffer(
         renderbuffer,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromGLRenderbuffer_disp(
     cl_context context,
@@ -6483,6 +6466,9 @@ static cl_mem CL_API_CALL clCreateFromGLRenderbuffer_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clGetGLObjectInfo(
     cl_mem memobj,
@@ -6503,6 +6489,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLObjectInfo(
         gl_object_type,
         gl_object_name);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetGLObjectInfo_disp(
     cl_mem memobj,
@@ -6517,6 +6504,9 @@ static cl_int CL_API_CALL clGetGLObjectInfo_disp(
         gl_object_name);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clGetGLTextureInfo(
     cl_mem memobj,
@@ -6543,6 +6533,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLTextureInfo(
         param_value,
         param_value_size_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetGLTextureInfo_disp(
     cl_mem memobj,
@@ -6561,6 +6552,9 @@ static cl_int CL_API_CALL clGetGLTextureInfo_disp(
         param_value_size_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireGLObjects(
     cl_command_queue command_queue,
@@ -6590,6 +6584,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireGLObjects(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueAcquireGLObjects_disp(
     cl_command_queue command_queue,
@@ -6610,6 +6605,9 @@ static cl_int CL_API_CALL clEnqueueAcquireGLObjects_disp(
         event);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseGLObjects(
     cl_command_queue command_queue,
@@ -6639,6 +6637,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseGLObjects(
         event_wait_list,
         event);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clEnqueueReleaseGLObjects_disp(
     cl_command_queue command_queue,
@@ -6659,6 +6658,9 @@ static cl_int CL_API_CALL clEnqueueReleaseGLObjects_disp(
         event);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture2D(
     cl_context context,
@@ -6688,6 +6690,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture2D(
         texture,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromGLTexture2D_disp(
     cl_context context,
@@ -6708,6 +6711,9 @@ static cl_mem CL_API_CALL clCreateFromGLTexture2D_disp(
         errcode_ret);
 }
 #endif // defined(CL_ENABLE_LAYERS)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture3D(
     cl_context context,
@@ -6737,6 +6743,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromGLTexture3D(
         texture,
         errcode_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_mem CL_API_CALL clCreateFromGLTexture3D_disp(
     cl_context context,
@@ -6758,8 +6765,8 @@ static cl_mem CL_API_CALL clCreateFromGLTexture3D_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
-///////////////////////////////////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_subgroups
 
 CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
@@ -6796,6 +6803,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
         param_value,
         param_value_size_ret);
 }
+
 #if defined(CL_ENABLE_LAYERS)
 static cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_disp(
     cl_kernel in_kernel,
@@ -7029,6 +7037,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clSetContextDestructorCallback_disp
 };
 #endif // defined(CL_ENABLE_LAYERS)
+
 #ifdef __cplusplus
 }
 #endif

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -38,6 +38,9 @@ static cl_int CL_API_CALL clGetPlatformIDs_shutdown(
     cl_platform_id* platforms,
     cl_uint* num_platforms)
 {
+    (void)num_entries;
+    (void)platforms;
+    (void)num_platforms;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -95,6 +98,11 @@ static cl_int CL_API_CALL clGetPlatformInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)platform;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -152,6 +160,11 @@ static cl_int CL_API_CALL clGetDeviceIDs_shutdown(
     cl_device_id* devices,
     cl_uint* num_devices)
 {
+    (void)platform;
+    (void)device_type;
+    (void)num_entries;
+    (void)devices;
+    (void)num_devices;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -209,6 +222,11 @@ static cl_int CL_API_CALL clGetDeviceInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)device;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -278,6 +296,11 @@ static cl_context CL_API_CALL clCreateContext_shutdown(
     void* user_data,
     cl_int* errcode_ret)
 {
+    (void)properties;
+    (void)num_devices;
+    (void)devices;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -341,6 +364,10 @@ static cl_context CL_API_CALL clCreateContextFromType_shutdown(
     void* user_data,
     cl_int* errcode_ret)
 {
+    (void)properties;
+    (void)device_type;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -374,6 +401,7 @@ static cl_int CL_API_CALL clRetainContext_disp(
 static cl_int CL_API_CALL clRetainContext_shutdown(
     cl_context context)
 {
+    (void)context;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -407,6 +435,7 @@ static cl_int CL_API_CALL clReleaseContext_disp(
 static cl_int CL_API_CALL clReleaseContext_shutdown(
     cl_context context)
 {
+    (void)context;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -464,6 +493,11 @@ static cl_int CL_API_CALL clGetContextInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)context;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -497,6 +531,7 @@ static cl_int CL_API_CALL clRetainCommandQueue_disp(
 static cl_int CL_API_CALL clRetainCommandQueue_shutdown(
     cl_command_queue command_queue)
 {
+    (void)command_queue;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -530,6 +565,7 @@ static cl_int CL_API_CALL clReleaseCommandQueue_disp(
 static cl_int CL_API_CALL clReleaseCommandQueue_shutdown(
     cl_command_queue command_queue)
 {
+    (void)command_queue;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -587,6 +623,11 @@ static cl_int CL_API_CALL clGetCommandQueueInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)command_queue;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -644,6 +685,10 @@ static cl_mem CL_API_CALL clCreateBuffer_shutdown(
     void* host_ptr,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)size;
+    (void)host_ptr;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -677,6 +722,7 @@ static cl_int CL_API_CALL clRetainMemObject_disp(
 static cl_int CL_API_CALL clRetainMemObject_shutdown(
     cl_mem memobj)
 {
+    (void)memobj;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -710,6 +756,7 @@ static cl_int CL_API_CALL clReleaseMemObject_disp(
 static cl_int CL_API_CALL clReleaseMemObject_shutdown(
     cl_mem memobj)
 {
+    (void)memobj;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -773,6 +820,12 @@ static cl_int CL_API_CALL clGetSupportedImageFormats_shutdown(
     cl_image_format* image_formats,
     cl_uint* num_image_formats)
 {
+    (void)context;
+    (void)flags;
+    (void)image_type;
+    (void)num_entries;
+    (void)image_formats;
+    (void)num_image_formats;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -830,6 +883,11 @@ static cl_int CL_API_CALL clGetMemObjectInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)memobj;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -887,6 +945,11 @@ static cl_int CL_API_CALL clGetImageInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)image;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -920,6 +983,7 @@ static cl_int CL_API_CALL clRetainSampler_disp(
 static cl_int CL_API_CALL clRetainSampler_shutdown(
     cl_sampler sampler)
 {
+    (void)sampler;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -953,6 +1017,7 @@ static cl_int CL_API_CALL clReleaseSampler_disp(
 static cl_int CL_API_CALL clReleaseSampler_shutdown(
     cl_sampler sampler)
 {
+    (void)sampler;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1010,6 +1075,11 @@ static cl_int CL_API_CALL clGetSamplerInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)sampler;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1067,6 +1137,10 @@ static cl_program CL_API_CALL clCreateProgramWithSource_shutdown(
     const size_t* lengths,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)count;
+    (void)strings;
+    (void)lengths;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1136,6 +1210,12 @@ static cl_program CL_API_CALL clCreateProgramWithBinary_shutdown(
     cl_int* binary_status,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)num_devices;
+    (void)device_list;
+    (void)lengths;
+    (void)binaries;
+    (void)binary_status;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1169,6 +1249,7 @@ static cl_int CL_API_CALL clRetainProgram_disp(
 static cl_int CL_API_CALL clRetainProgram_shutdown(
     cl_program program)
 {
+    (void)program;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1202,6 +1283,7 @@ static cl_int CL_API_CALL clReleaseProgram_disp(
 static cl_int CL_API_CALL clReleaseProgram_shutdown(
     cl_program program)
 {
+    (void)program;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1265,6 +1347,12 @@ static cl_int CL_API_CALL clBuildProgram_shutdown(
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
     void* user_data)
 {
+    (void)program;
+    (void)num_devices;
+    (void)device_list;
+    (void)options;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1322,6 +1410,11 @@ static cl_int CL_API_CALL clGetProgramInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)program;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1385,6 +1478,12 @@ static cl_int CL_API_CALL clGetProgramBuildInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)program;
+    (void)device;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1430,6 +1529,8 @@ static cl_kernel CL_API_CALL clCreateKernel_shutdown(
     const char* kernel_name,
     cl_int* errcode_ret)
 {
+    (void)program;
+    (void)kernel_name;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1481,6 +1582,10 @@ static cl_int CL_API_CALL clCreateKernelsInProgram_shutdown(
     cl_kernel* kernels,
     cl_uint* num_kernels_ret)
 {
+    (void)program;
+    (void)num_kernels;
+    (void)kernels;
+    (void)num_kernels_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1514,6 +1619,7 @@ static cl_int CL_API_CALL clRetainKernel_disp(
 static cl_int CL_API_CALL clRetainKernel_shutdown(
     cl_kernel kernel)
 {
+    (void)kernel;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1547,6 +1653,7 @@ static cl_int CL_API_CALL clReleaseKernel_disp(
 static cl_int CL_API_CALL clReleaseKernel_shutdown(
     cl_kernel kernel)
 {
+    (void)kernel;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1598,6 +1705,10 @@ static cl_int CL_API_CALL clSetKernelArg_shutdown(
     size_t arg_size,
     const void* arg_value)
 {
+    (void)kernel;
+    (void)arg_index;
+    (void)arg_size;
+    (void)arg_value;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1655,6 +1766,11 @@ static cl_int CL_API_CALL clGetKernelInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)kernel;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1718,6 +1834,12 @@ static cl_int CL_API_CALL clGetKernelWorkGroupInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)kernel;
+    (void)device;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1763,6 +1885,8 @@ static cl_int CL_API_CALL clWaitForEvents_shutdown(
     cl_uint num_events,
     const cl_event* event_list)
 {
+    (void)num_events;
+    (void)event_list;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1820,6 +1944,11 @@ static cl_int CL_API_CALL clGetEventInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)event;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1853,6 +1982,7 @@ static cl_int CL_API_CALL clRetainEvent_disp(
 static cl_int CL_API_CALL clRetainEvent_shutdown(
     cl_event event)
 {
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1886,6 +2016,7 @@ static cl_int CL_API_CALL clReleaseEvent_disp(
 static cl_int CL_API_CALL clReleaseEvent_shutdown(
     cl_event event)
 {
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1943,6 +2074,11 @@ static cl_int CL_API_CALL clGetEventProfilingInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)event;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -1976,6 +2112,7 @@ static cl_int CL_API_CALL clFlush_disp(
 static cl_int CL_API_CALL clFlush_shutdown(
     cl_command_queue command_queue)
 {
+    (void)command_queue;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2009,6 +2146,7 @@ static cl_int CL_API_CALL clFinish_disp(
 static cl_int CL_API_CALL clFinish_shutdown(
     cl_command_queue command_queue)
 {
+    (void)command_queue;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2090,6 +2228,15 @@ static cl_int CL_API_CALL clEnqueueReadBuffer_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)buffer;
+    (void)blocking_read;
+    (void)offset;
+    (void)size;
+    (void)ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2171,6 +2318,15 @@ static cl_int CL_API_CALL clEnqueueWriteBuffer_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)buffer;
+    (void)blocking_write;
+    (void)offset;
+    (void)size;
+    (void)ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2252,6 +2408,15 @@ static cl_int CL_API_CALL clEnqueueCopyBuffer_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)src_buffer;
+    (void)dst_buffer;
+    (void)src_offset;
+    (void)dst_offset;
+    (void)size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2345,6 +2510,17 @@ static cl_int CL_API_CALL clEnqueueReadImage_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)image;
+    (void)blocking_read;
+    (void)origin;
+    (void)region;
+    (void)row_pitch;
+    (void)slice_pitch;
+    (void)ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2438,6 +2614,17 @@ static cl_int CL_API_CALL clEnqueueWriteImage_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)image;
+    (void)blocking_write;
+    (void)origin;
+    (void)region;
+    (void)input_row_pitch;
+    (void)input_slice_pitch;
+    (void)ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2519,6 +2706,15 @@ static cl_int CL_API_CALL clEnqueueCopyImage_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)src_image;
+    (void)dst_image;
+    (void)src_origin;
+    (void)dst_origin;
+    (void)region;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2600,6 +2796,15 @@ static cl_int CL_API_CALL clEnqueueCopyImageToBuffer_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)src_image;
+    (void)dst_buffer;
+    (void)src_origin;
+    (void)region;
+    (void)dst_offset;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2681,6 +2886,15 @@ static cl_int CL_API_CALL clEnqueueCopyBufferToImage_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)src_buffer;
+    (void)dst_image;
+    (void)src_offset;
+    (void)dst_origin;
+    (void)region;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2768,6 +2982,15 @@ static void* CL_API_CALL clEnqueueMapBuffer_shutdown(
     cl_event* event,
     cl_int* errcode_ret)
 {
+    (void)command_queue;
+    (void)buffer;
+    (void)blocking_map;
+    (void)map_flags;
+    (void)offset;
+    (void)size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2867,6 +3090,17 @@ static void* CL_API_CALL clEnqueueMapImage_shutdown(
     cl_event* event,
     cl_int* errcode_ret)
 {
+    (void)command_queue;
+    (void)image;
+    (void)blocking_map;
+    (void)map_flags;
+    (void)origin;
+    (void)region;
+    (void)image_row_pitch;
+    (void)image_slice_pitch;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -2930,6 +3164,12 @@ static cl_int CL_API_CALL clEnqueueUnmapMemObject_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)memobj;
+    (void)mapped_ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3011,6 +3251,15 @@ static cl_int CL_API_CALL clEnqueueNDRangeKernel_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)kernel;
+    (void)work_dim;
+    (void)global_work_offset;
+    (void)global_work_size;
+    (void)local_work_size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3098,6 +3347,16 @@ static cl_int CL_API_CALL clEnqueueNativeKernel_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)user_func;
+    (void)args;
+    (void)cb_args;
+    (void)num_mem_objects;
+    (void)mem_list;
+    (void)args_mem_loc;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3149,6 +3408,10 @@ static cl_int CL_API_CALL clSetCommandQueueProperty_shutdown(
     cl_bool enable,
     cl_command_queue_properties* old_properties)
 {
+    (void)command_queue;
+    (void)properties;
+    (void)enable;
+    (void)old_properties;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3224,6 +3487,13 @@ static cl_mem CL_API_CALL clCreateImage2D_shutdown(
     void* host_ptr,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)image_format;
+    (void)image_width;
+    (void)image_height;
+    (void)image_row_pitch;
+    (void)host_ptr;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3311,6 +3581,15 @@ static cl_mem CL_API_CALL clCreateImage3D_shutdown(
     void* host_ptr,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)image_format;
+    (void)image_width;
+    (void)image_height;
+    (void)image_depth;
+    (void)image_row_pitch;
+    (void)image_slice_pitch;
+    (void)host_ptr;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3350,6 +3629,8 @@ static cl_int CL_API_CALL clEnqueueMarker_shutdown(
     cl_command_queue command_queue,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3395,6 +3676,9 @@ static cl_int CL_API_CALL clEnqueueWaitForEvents_shutdown(
     cl_uint num_events,
     const cl_event* event_list)
 {
+    (void)command_queue;
+    (void)num_events;
+    (void)event_list;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3428,6 +3712,7 @@ static cl_int CL_API_CALL clEnqueueBarrier_disp(
 static cl_int CL_API_CALL clEnqueueBarrier_shutdown(
     cl_command_queue command_queue)
 {
+    (void)command_queue;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3474,6 +3759,7 @@ extern void* CL_API_CALL clGetExtensionFunctionAddress_disp(
 static void* CL_API_CALL clGetExtensionFunctionAddress_shutdown(
     const char* func_name)
 {
+    (void)func_name;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3525,6 +3811,9 @@ static cl_command_queue CL_API_CALL clCreateCommandQueue_shutdown(
     cl_command_queue_properties properties,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)device;
+    (void)properties;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3582,6 +3871,10 @@ static cl_sampler CL_API_CALL clCreateSampler_shutdown(
     cl_filter_mode filter_mode,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)normalized_coords;
+    (void)addressing_mode;
+    (void)filter_mode;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3639,6 +3932,11 @@ static cl_int CL_API_CALL clEnqueueTask_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)kernel;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3696,6 +3994,10 @@ static cl_mem CL_API_CALL clCreateSubBuffer_shutdown(
     const void* buffer_create_info,
     cl_int* errcode_ret)
 {
+    (void)buffer;
+    (void)flags;
+    (void)buffer_create_type;
+    (void)buffer_create_info;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3741,6 +4043,9 @@ static cl_int CL_API_CALL clSetMemObjectDestructorCallback_shutdown(
     void (CL_CALLBACK* pfn_notify)(cl_mem memobj, void* user_data),
     void* user_data)
 {
+    (void)memobj;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3780,6 +4085,7 @@ static cl_event CL_API_CALL clCreateUserEvent_shutdown(
     cl_context context,
     cl_int* errcode_ret)
 {
+    (void)context;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3819,6 +4125,8 @@ static cl_int CL_API_CALL clSetUserEventStatus_shutdown(
     cl_event event,
     cl_int execution_status)
 {
+    (void)event;
+    (void)execution_status;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3870,6 +4178,10 @@ static cl_int CL_API_CALL clSetEventCallback_shutdown(
     void (CL_CALLBACK* pfn_notify)(cl_event event, cl_int event_command_status, void *user_data),
     void* user_data)
 {
+    (void)event;
+    (void)command_exec_callback_type;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -3981,6 +4293,20 @@ static cl_int CL_API_CALL clEnqueueReadBufferRect_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)buffer;
+    (void)blocking_read;
+    (void)buffer_origin;
+    (void)host_origin;
+    (void)region;
+    (void)buffer_row_pitch;
+    (void)buffer_slice_pitch;
+    (void)host_row_pitch;
+    (void)host_slice_pitch;
+    (void)ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4092,6 +4418,20 @@ static cl_int CL_API_CALL clEnqueueWriteBufferRect_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)buffer;
+    (void)blocking_write;
+    (void)buffer_origin;
+    (void)host_origin;
+    (void)region;
+    (void)buffer_row_pitch;
+    (void)buffer_slice_pitch;
+    (void)host_row_pitch;
+    (void)host_slice_pitch;
+    (void)ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4197,6 +4537,19 @@ static cl_int CL_API_CALL clEnqueueCopyBufferRect_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)src_buffer;
+    (void)dst_buffer;
+    (void)src_origin;
+    (void)dst_origin;
+    (void)region;
+    (void)src_row_pitch;
+    (void)src_slice_pitch;
+    (void)dst_row_pitch;
+    (void)dst_slice_pitch;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4254,6 +4607,11 @@ static cl_int CL_API_CALL clCreateSubDevices_shutdown(
     cl_device_id* out_devices,
     cl_uint* num_devices_ret)
 {
+    (void)in_device;
+    (void)properties;
+    (void)num_devices;
+    (void)out_devices;
+    (void)num_devices_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4287,6 +4645,7 @@ static cl_int CL_API_CALL clRetainDevice_disp(
 static cl_int CL_API_CALL clRetainDevice_shutdown(
     cl_device_id device)
 {
+    (void)device;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4320,6 +4679,7 @@ static cl_int CL_API_CALL clReleaseDevice_disp(
 static cl_int CL_API_CALL clReleaseDevice_shutdown(
     cl_device_id device)
 {
+    (void)device;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4383,6 +4743,11 @@ static cl_mem CL_API_CALL clCreateImage_shutdown(
     void* host_ptr,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)image_format;
+    (void)image_desc;
+    (void)host_ptr;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4440,6 +4805,10 @@ static cl_program CL_API_CALL clCreateProgramWithBuiltInKernels_shutdown(
     const char* kernel_names,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)num_devices;
+    (void)device_list;
+    (void)kernel_names;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4521,6 +4890,15 @@ static cl_int CL_API_CALL clCompileProgram_shutdown(
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
     void* user_data)
 {
+    (void)program;
+    (void)num_devices;
+    (void)device_list;
+    (void)options;
+    (void)num_input_headers;
+    (void)input_headers;
+    (void)header_include_names;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4602,6 +4980,14 @@ static cl_program CL_API_CALL clLinkProgram_shutdown(
     void* user_data,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)num_devices;
+    (void)device_list;
+    (void)options;
+    (void)num_input_programs;
+    (void)input_programs;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4635,6 +5021,7 @@ static cl_int CL_API_CALL clUnloadPlatformCompiler_disp(
 static cl_int CL_API_CALL clUnloadPlatformCompiler_shutdown(
     cl_platform_id platform)
 {
+    (void)platform;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4698,6 +5085,12 @@ static cl_int CL_API_CALL clGetKernelArgInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)kernel;
+    (void)arg_index;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4779,6 +5172,15 @@ static cl_int CL_API_CALL clEnqueueFillBuffer_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)buffer;
+    (void)pattern;
+    (void)pattern_size;
+    (void)offset;
+    (void)size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4854,6 +5256,14 @@ static cl_int CL_API_CALL clEnqueueFillImage_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)image;
+    (void)fill_color;
+    (void)origin;
+    (void)region;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4923,6 +5333,13 @@ static cl_int CL_API_CALL clEnqueueMigrateMemObjects_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_mem_objects;
+    (void)mem_objects;
+    (void)flags;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -4974,6 +5391,10 @@ static cl_int CL_API_CALL clEnqueueMarkerWithWaitList_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5025,6 +5446,10 @@ static cl_int CL_API_CALL clEnqueueBarrierWithWaitList_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5042,6 +5467,8 @@ static void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_shutdown(
     cl_platform_id platform,
     const char* func_name)
 {
+    (void)platform;
+    (void)func_name;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5093,6 +5520,9 @@ static cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties_shutdown(
     const cl_queue_properties* properties,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)device;
+    (void)properties;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5156,6 +5586,11 @@ static cl_mem CL_API_CALL clCreatePipe_shutdown(
     const cl_pipe_properties* properties,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)pipe_packet_size;
+    (void)pipe_max_packets;
+    (void)properties;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5213,6 +5648,11 @@ static cl_int CL_API_CALL clGetPipeInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)pipe;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5264,6 +5704,10 @@ static void* CL_API_CALL clSVMAlloc_shutdown(
     size_t size,
     cl_uint alignment)
 {
+    (void)context;
+    (void)flags;
+    (void)size;
+    (void)alignment;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5306,6 +5750,8 @@ static void CL_API_CALL clSVMFree_shutdown(
     cl_context context,
     void* svm_pointer)
 {
+    (void)context;
+    (void)svm_pointer;
     // Nothing!
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5351,6 +5797,8 @@ static cl_sampler CL_API_CALL clCreateSamplerWithProperties_shutdown(
     const cl_sampler_properties* sampler_properties,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)sampler_properties;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5396,6 +5844,9 @@ static cl_int CL_API_CALL clSetKernelArgSVMPointer_shutdown(
     cl_uint arg_index,
     const void* arg_value)
 {
+    (void)kernel;
+    (void)arg_index;
+    (void)arg_value;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5447,6 +5898,10 @@ static cl_int CL_API_CALL clSetKernelExecInfo_shutdown(
     size_t param_value_size,
     const void* param_value)
 {
+    (void)kernel;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5522,6 +5977,14 @@ static cl_int CL_API_CALL clEnqueueSVMFree_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_svm_pointers;
+    (void)svm_pointers;
+    (void)pfn_free_func;
+    (void)user_data;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5597,6 +6060,14 @@ static cl_int CL_API_CALL clEnqueueSVMMemcpy_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)blocking_copy;
+    (void)dst_ptr;
+    (void)src_ptr;
+    (void)size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5672,6 +6143,14 @@ static cl_int CL_API_CALL clEnqueueSVMMemFill_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)svm_ptr;
+    (void)pattern;
+    (void)pattern_size;
+    (void)size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5747,6 +6226,14 @@ static cl_int CL_API_CALL clEnqueueSVMMap_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)blocking_map;
+    (void)flags;
+    (void)svm_ptr;
+    (void)size;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5804,6 +6291,11 @@ static cl_int CL_API_CALL clEnqueueSVMUnmap_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)svm_ptr;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5849,6 +6341,9 @@ static cl_int CL_API_CALL clSetDefaultDeviceCommandQueue_shutdown(
     cl_device_id device,
     cl_command_queue command_queue)
 {
+    (void)context;
+    (void)device;
+    (void)command_queue;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5894,6 +6389,9 @@ static cl_int CL_API_CALL clGetDeviceAndHostTimer_shutdown(
     cl_ulong* device_timestamp,
     cl_ulong* host_timestamp)
 {
+    (void)device;
+    (void)device_timestamp;
+    (void)host_timestamp;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5933,6 +6431,8 @@ static cl_int CL_API_CALL clGetHostTimer_shutdown(
     cl_device_id device,
     cl_ulong* host_timestamp)
 {
+    (void)device;
+    (void)host_timestamp;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -5984,6 +6484,9 @@ static cl_program CL_API_CALL clCreateProgramWithIL_shutdown(
     size_t length,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)il;
+    (void)length;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6023,6 +6526,7 @@ static cl_kernel CL_API_CALL clCloneKernel_shutdown(
     cl_kernel source_kernel,
     cl_int* errcode_ret)
 {
+    (void)source_kernel;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6098,6 +6602,14 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)kernel;
+    (void)device;
+    (void)param_name;
+    (void)input_value_size;
+    (void)input_value;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6173,6 +6685,14 @@ static cl_int CL_API_CALL clEnqueueSVMMigrateMem_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_svm_pointers;
+    (void)svm_pointers;
+    (void)sizes;
+    (void)flags;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6224,6 +6744,10 @@ static cl_int CL_API_CALL clSetProgramSpecializationConstant_shutdown(
     size_t spec_size,
     const void* spec_value)
 {
+    (void)program;
+    (void)spec_id;
+    (void)spec_size;
+    (void)spec_value;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6269,6 +6793,9 @@ static cl_int CL_API_CALL clSetProgramReleaseCallback_shutdown(
     void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
     void* user_data)
 {
+    (void)program;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6314,6 +6841,9 @@ static cl_int CL_API_CALL clSetContextDestructorCallback_shutdown(
     void (CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
     void* user_data)
 {
+    (void)context;
+    (void)pfn_notify;
+    (void)user_data;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6377,6 +6907,11 @@ static cl_mem CL_API_CALL clCreateBufferWithProperties_shutdown(
     void* host_ptr,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)properties;
+    (void)flags;
+    (void)size;
+    (void)host_ptr;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6446,6 +6981,12 @@ static cl_mem CL_API_CALL clCreateImageWithProperties_shutdown(
     void* host_ptr,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)properties;
+    (void)flags;
+    (void)image_format;
+    (void)image_desc;
+    (void)host_ptr;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6484,6 +7025,7 @@ static cl_int CL_API_CALL clReleaseDeviceEXT_disp(
 static cl_int CL_API_CALL clReleaseDeviceEXT_shutdown(
     cl_device_id device)
 {
+    (void)device;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6520,6 +7062,7 @@ static cl_int CL_API_CALL clRetainDeviceEXT_disp(
 static cl_int CL_API_CALL clRetainDeviceEXT_shutdown(
     cl_device_id device)
 {
+    (void)device;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6580,6 +7123,11 @@ static cl_int CL_API_CALL clCreateSubDevicesEXT_shutdown(
     cl_device_id* out_devices,
     cl_uint* num_devices)
 {
+    (void)in_device;
+    (void)properties;
+    (void)num_entries;
+    (void)out_devices;
+    (void)num_devices;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6655,6 +7203,13 @@ static cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR_shutdown(
     cl_device_id* devices,
     cl_uint* num_devices)
 {
+    (void)platform;
+    (void)d3d_device_source;
+    (void)d3d_object;
+    (void)d3d_device_set;
+    (void)num_entries;
+    (void)devices;
+    (void)num_devices;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6709,6 +7264,9 @@ static cl_mem CL_API_CALL clCreateFromD3D10BufferKHR_shutdown(
     ID3D10Buffer* resource,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)resource;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6769,6 +7327,10 @@ static cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR_shutdown(
     UINT subresource,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)resource;
+    (void)subresource;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6829,6 +7391,10 @@ static cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR_shutdown(
     UINT subresource,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)resource;
+    (void)subresource;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6895,6 +7461,12 @@ static cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -6961,6 +7533,12 @@ static cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7037,6 +7615,13 @@ static cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR_shutdown(
     cl_device_id* devices,
     cl_uint* num_devices)
 {
+    (void)platform;
+    (void)d3d_device_source;
+    (void)d3d_object;
+    (void)d3d_device_set;
+    (void)num_entries;
+    (void)devices;
+    (void)num_devices;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7091,6 +7676,9 @@ static cl_mem CL_API_CALL clCreateFromD3D11BufferKHR_shutdown(
     ID3D11Buffer* resource,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)resource;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7151,6 +7739,10 @@ static cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR_shutdown(
     UINT subresource,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)resource;
+    (void)subresource;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7211,6 +7803,10 @@ static cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR_shutdown(
     UINT subresource,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)resource;
+    (void)subresource;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7277,6 +7873,12 @@ static cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7343,6 +7945,12 @@ static cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7425,6 +8033,14 @@ static cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR_shutdown(
     cl_device_id* devices,
     cl_uint* num_devices)
 {
+    (void)platform;
+    (void)num_media_adapters;
+    (void)media_adapter_type;
+    (void)media_adapters;
+    (void)media_adapter_set;
+    (void)num_entries;
+    (void)devices;
+    (void)num_devices;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7491,6 +8107,11 @@ static cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR_shutdown(
     cl_uint plane,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)adapter_type;
+    (void)surface_info;
+    (void)plane;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7557,6 +8178,12 @@ static cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7623,6 +8250,12 @@ static cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7679,6 +8312,9 @@ static cl_event CL_API_CALL clCreateEventFromEGLSyncKHR_shutdown(
     CLeglDisplayKHR display,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)sync;
+    (void)display;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7746,6 +8382,11 @@ static cl_mem CL_API_CALL clCreateFromEGLImageKHR_shutdown(
     const cl_egl_image_properties_khr* properties,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)egldisplay;
+    (void)eglimage;
+    (void)flags;
+    (void)properties;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7812,6 +8453,12 @@ static cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7878,6 +8525,12 @@ static cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7927,6 +8580,8 @@ static cl_event CL_API_CALL clCreateEventFromGLsyncKHR_shutdown(
     cl_GLsync sync,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)sync;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -7992,6 +8647,11 @@ static cl_int CL_API_CALL clGetGLContextInfoKHR_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)properties;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8046,6 +8706,9 @@ static cl_mem CL_API_CALL clCreateFromGLBuffer_shutdown(
     cl_GLuint bufobj,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)bufobj;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8112,6 +8775,11 @@ static cl_mem CL_API_CALL clCreateFromGLTexture_shutdown(
     cl_GLuint texture,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)target;
+    (void)miplevel;
+    (void)texture;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8166,6 +8834,9 @@ static cl_mem CL_API_CALL clCreateFromGLRenderbuffer_shutdown(
     cl_GLuint renderbuffer,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)renderbuffer;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8214,6 +8885,9 @@ static cl_int CL_API_CALL clGetGLObjectInfo_shutdown(
     cl_gl_object_type* gl_object_type,
     cl_GLuint* gl_object_name)
 {
+    (void)memobj;
+    (void)gl_object_type;
+    (void)gl_object_name;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8274,6 +8948,11 @@ static cl_int CL_API_CALL clGetGLTextureInfo_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)memobj;
+    (void)param_name;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8340,6 +9019,12 @@ static cl_int CL_API_CALL clEnqueueAcquireGLObjects_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8406,6 +9091,12 @@ static cl_int CL_API_CALL clEnqueueReleaseGLObjects_shutdown(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    (void)command_queue;
+    (void)num_objects;
+    (void)mem_objects;
+    (void)num_events_in_wait_list;
+    (void)event_wait_list;
+    (void)event;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8472,6 +9163,11 @@ static cl_mem CL_API_CALL clCreateFromGLTexture2D_shutdown(
     cl_GLuint texture,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)target;
+    (void)miplevel;
+    (void)texture;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8538,6 +9234,11 @@ static cl_mem CL_API_CALL clCreateFromGLTexture3D_shutdown(
     cl_GLuint texture,
     cl_int* errcode_ret)
 {
+    (void)context;
+    (void)flags;
+    (void)target;
+    (void)miplevel;
+    (void)texture;
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
@@ -8617,6 +9318,14 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_shutdown(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    (void)in_kernel;
+    (void)in_device;
+    (void)param_name;
+    (void)input_value_size;
+    (void)input_value;
+    (void)param_value_size;
+    (void)param_value;
+    (void)param_value_size_ret;
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -77,6 +77,18 @@ static cl_int CL_API_CALL clGetPlatformInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetPlatformInfo_shutdown(
+    cl_platform_id platform,
+    cl_platform_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDs(
@@ -122,6 +134,18 @@ static cl_int CL_API_CALL clGetDeviceIDs_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetDeviceIDs_shutdown(
+    cl_platform_id platform,
+    cl_device_type device_type,
+    cl_uint num_entries,
+    cl_device_id* devices,
+    cl_uint* num_devices)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfo(
@@ -164,6 +188,18 @@ static cl_int CL_API_CALL clGetDeviceInfo_disp(
         param_value_size,
         param_value,
         param_value_size_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetDeviceInfo_shutdown(
+    cl_device_id device,
+    cl_device_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -223,6 +259,19 @@ static cl_context CL_API_CALL clCreateContext_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_context CL_API_CALL clCreateContext_shutdown(
+    const cl_context_properties* properties,
+    cl_uint num_devices,
+    const cl_device_id* devices,
+    void (CL_CALLBACK* pfn_notify)(const char* errinfo, const void* private_info, size_t cb, void* user_data),
+    void* user_data,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_context CL_API_CALL clCreateContextFromType(
@@ -274,6 +323,18 @@ static cl_context CL_API_CALL clCreateContextFromType_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_context CL_API_CALL clCreateContextFromType_shutdown(
+    const cl_context_properties* properties,
+    cl_device_type device_type,
+    void (CL_CALLBACK* pfn_notify)(const char* errinfo, const void* private_info, size_t cb, void* user_data),
+    void* user_data,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainContext(
@@ -299,6 +360,14 @@ static cl_int CL_API_CALL clRetainContext_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainContext_shutdown(
+    cl_context context)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseContext(
@@ -321,6 +390,14 @@ static cl_int CL_API_CALL clReleaseContext_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(context, CL_INVALID_CONTEXT);
     return context->dispatch->clReleaseContext(
         context);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseContext_shutdown(
+    cl_context context)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -369,6 +446,18 @@ static cl_int CL_API_CALL clGetContextInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetContextInfo_shutdown(
+    cl_context context,
+    cl_context_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainCommandQueue(
@@ -394,6 +483,14 @@ static cl_int CL_API_CALL clRetainCommandQueue_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainCommandQueue_shutdown(
+    cl_command_queue command_queue)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseCommandQueue(
@@ -416,6 +513,14 @@ static cl_int CL_API_CALL clReleaseCommandQueue_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clReleaseCommandQueue(
         command_queue);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseCommandQueue_shutdown(
+    cl_command_queue command_queue)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -464,6 +569,18 @@ static cl_int CL_API_CALL clGetCommandQueueInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetCommandQueueInfo_shutdown(
+    cl_command_queue command_queue,
+    cl_command_queue_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateBuffer(
@@ -509,6 +626,18 @@ static cl_mem CL_API_CALL clCreateBuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateBuffer_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    size_t size,
+    void* host_ptr,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainMemObject(
@@ -534,6 +663,14 @@ static cl_int CL_API_CALL clRetainMemObject_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainMemObject_shutdown(
+    cl_mem memobj)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseMemObject(
@@ -556,6 +693,14 @@ static cl_int CL_API_CALL clReleaseMemObject_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(memobj, CL_INVALID_MEM_OBJECT);
     return memobj->dispatch->clReleaseMemObject(
         memobj);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseMemObject_shutdown(
+    cl_mem memobj)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -609,6 +754,19 @@ static cl_int CL_API_CALL clGetSupportedImageFormats_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetSupportedImageFormats_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_mem_object_type image_type,
+    cl_uint num_entries,
+    cl_image_format* image_formats,
+    cl_uint* num_image_formats)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetMemObjectInfo(
@@ -651,6 +809,18 @@ static cl_int CL_API_CALL clGetMemObjectInfo_disp(
         param_value_size,
         param_value,
         param_value_size_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetMemObjectInfo_shutdown(
+    cl_mem memobj,
+    cl_mem_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -699,6 +869,18 @@ static cl_int CL_API_CALL clGetImageInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetImageInfo_shutdown(
+    cl_mem image,
+    cl_image_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainSampler(
@@ -724,6 +906,14 @@ static cl_int CL_API_CALL clRetainSampler_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainSampler_shutdown(
+    cl_sampler sampler)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseSampler(
@@ -746,6 +936,14 @@ static cl_int CL_API_CALL clReleaseSampler_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(sampler, CL_INVALID_SAMPLER);
     return sampler->dispatch->clReleaseSampler(
         sampler);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseSampler_shutdown(
+    cl_sampler sampler)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -794,6 +992,18 @@ static cl_int CL_API_CALL clGetSamplerInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetSamplerInfo_shutdown(
+    cl_sampler sampler,
+    cl_sampler_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithSource(
@@ -836,6 +1046,18 @@ static cl_program CL_API_CALL clCreateProgramWithSource_disp(
         strings,
         lengths,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_program CL_API_CALL clCreateProgramWithSource_shutdown(
+    cl_context context,
+    cl_uint count,
+    const char** strings,
+    const size_t* lengths,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -894,6 +1116,20 @@ static cl_program CL_API_CALL clCreateProgramWithBinary_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_program CL_API_CALL clCreateProgramWithBinary_shutdown(
+    cl_context context,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const size_t* lengths,
+    const unsigned char** binaries,
+    cl_int* binary_status,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainProgram(
@@ -919,6 +1155,14 @@ static cl_int CL_API_CALL clRetainProgram_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainProgram_shutdown(
+    cl_program program)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseProgram(
@@ -941,6 +1185,14 @@ static cl_int CL_API_CALL clReleaseProgram_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(program, CL_INVALID_PROGRAM);
     return program->dispatch->clReleaseProgram(
         program);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseProgram_shutdown(
+    cl_program program)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -994,6 +1246,19 @@ static cl_int CL_API_CALL clBuildProgram_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clBuildProgram_shutdown(
+    cl_program program,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const char* options,
+    void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+    void* user_data)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetProgramInfo(
@@ -1036,6 +1301,18 @@ static cl_int CL_API_CALL clGetProgramInfo_disp(
         param_value_size,
         param_value,
         param_value_size_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetProgramInfo_shutdown(
+    cl_program program,
+    cl_program_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1089,6 +1366,19 @@ static cl_int CL_API_CALL clGetProgramBuildInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetProgramBuildInfo_shutdown(
+    cl_program program,
+    cl_device_id device,
+    cl_program_build_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_kernel CL_API_CALL clCreateKernel(
@@ -1121,6 +1411,16 @@ static cl_kernel CL_API_CALL clCreateKernel_disp(
         program,
         kernel_name,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_kernel CL_API_CALL clCreateKernel_shutdown(
+    cl_program program,
+    const char* kernel_name,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1164,6 +1464,17 @@ static cl_int CL_API_CALL clCreateKernelsInProgram_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clCreateKernelsInProgram_shutdown(
+    cl_program program,
+    cl_uint num_kernels,
+    cl_kernel* kernels,
+    cl_uint* num_kernels_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainKernel(
@@ -1189,6 +1500,14 @@ static cl_int CL_API_CALL clRetainKernel_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainKernel_shutdown(
+    cl_kernel kernel)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseKernel(
@@ -1211,6 +1530,14 @@ static cl_int CL_API_CALL clReleaseKernel_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(kernel, CL_INVALID_KERNEL);
     return kernel->dispatch->clReleaseKernel(
         kernel);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseKernel_shutdown(
+    cl_kernel kernel)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1251,6 +1578,17 @@ static cl_int CL_API_CALL clSetKernelArg_disp(
         arg_index,
         arg_size,
         arg_value);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetKernelArg_shutdown(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    size_t arg_size,
+    const void* arg_value)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1296,6 +1634,18 @@ static cl_int CL_API_CALL clGetKernelInfo_disp(
         param_value_size,
         param_value,
         param_value_size_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetKernelInfo_shutdown(
+    cl_kernel kernel,
+    cl_kernel_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1349,6 +1699,19 @@ static cl_int CL_API_CALL clGetKernelWorkGroupInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetKernelWorkGroupInfo_shutdown(
+    cl_kernel kernel,
+    cl_device_id device,
+    cl_kernel_work_group_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clWaitForEvents(
@@ -1382,6 +1745,15 @@ static cl_int CL_API_CALL clWaitForEvents_disp(
     return event_list[0]->dispatch->clWaitForEvents(
         num_events,
         event_list);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clWaitForEvents_shutdown(
+    cl_uint num_events,
+    const cl_event* event_list)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1430,6 +1802,18 @@ static cl_int CL_API_CALL clGetEventInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetEventInfo_shutdown(
+    cl_event event,
+    cl_event_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainEvent(
@@ -1455,6 +1839,14 @@ static cl_int CL_API_CALL clRetainEvent_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainEvent_shutdown(
+    cl_event event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseEvent(
@@ -1477,6 +1869,14 @@ static cl_int CL_API_CALL clReleaseEvent_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(event, CL_INVALID_EVENT);
     return event->dispatch->clReleaseEvent(
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseEvent_shutdown(
+    cl_event event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1525,6 +1925,18 @@ static cl_int CL_API_CALL clGetEventProfilingInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetEventProfilingInfo_shutdown(
+    cl_event event,
+    cl_profiling_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clFlush(
@@ -1550,6 +1962,14 @@ static cl_int CL_API_CALL clFlush_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clFlush_shutdown(
+    cl_command_queue command_queue)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clFinish(
@@ -1572,6 +1992,14 @@ static cl_int CL_API_CALL clFinish_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(command_queue, CL_INVALID_COMMAND_QUEUE);
     return command_queue->dispatch->clFinish(
         command_queue);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clFinish_shutdown(
+    cl_command_queue command_queue)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1640,6 +2068,22 @@ static cl_int CL_API_CALL clEnqueueReadBuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReadBuffer_shutdown(
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    cl_bool blocking_read,
+    size_t offset,
+    size_t size,
+    void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBuffer(
@@ -1705,6 +2149,22 @@ static cl_int CL_API_CALL clEnqueueWriteBuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueWriteBuffer_shutdown(
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    cl_bool blocking_write,
+    size_t offset,
+    size_t size,
+    const void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBuffer(
@@ -1767,6 +2227,22 @@ static cl_int CL_API_CALL clEnqueueCopyBuffer_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueCopyBuffer_shutdown(
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_buffer,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -1845,6 +2321,24 @@ static cl_int CL_API_CALL clEnqueueReadImage_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReadImage_shutdown(
+    cl_command_queue command_queue,
+    cl_mem image,
+    cl_bool blocking_read,
+    const size_t* origin,
+    const size_t* region,
+    size_t row_pitch,
+    size_t slice_pitch,
+    void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteImage(
@@ -1920,6 +2414,24 @@ static cl_int CL_API_CALL clEnqueueWriteImage_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueWriteImage_shutdown(
+    cl_command_queue command_queue,
+    cl_mem image,
+    cl_bool blocking_write,
+    const size_t* origin,
+    const size_t* region,
+    size_t input_row_pitch,
+    size_t input_slice_pitch,
+    const void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyImage(
@@ -1982,6 +2494,22 @@ static cl_int CL_API_CALL clEnqueueCopyImage_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueCopyImage_shutdown(
+    cl_command_queue command_queue,
+    cl_mem src_image,
+    cl_mem dst_image,
+    const size_t* src_origin,
+    const size_t* dst_origin,
+    const size_t* region,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2050,6 +2578,22 @@ static cl_int CL_API_CALL clEnqueueCopyImageToBuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueCopyImageToBuffer_shutdown(
+    cl_command_queue command_queue,
+    cl_mem src_image,
+    cl_mem dst_buffer,
+    const size_t* src_origin,
+    const size_t* region,
+    size_t dst_offset,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferToImage(
@@ -2112,6 +2656,22 @@ static cl_int CL_API_CALL clEnqueueCopyBufferToImage_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueCopyBufferToImage_shutdown(
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_image,
+    size_t src_offset,
+    const size_t* dst_origin,
+    const size_t* region,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2182,6 +2742,23 @@ static void* CL_API_CALL clEnqueueMapBuffer_disp(
         event_wait_list,
         event,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static void* CL_API_CALL clEnqueueMapBuffer_shutdown(
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    cl_bool blocking_map,
+    cl_map_flags map_flags,
+    size_t offset,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2265,6 +2842,25 @@ static void* CL_API_CALL clEnqueueMapImage_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static void* CL_API_CALL clEnqueueMapImage_shutdown(
+    cl_command_queue command_queue,
+    cl_mem image,
+    cl_bool blocking_map,
+    cl_map_flags map_flags,
+    const size_t* origin,
+    const size_t* region,
+    size_t* image_row_pitch,
+    size_t* image_slice_pitch,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueUnmapMemObject(
@@ -2312,6 +2908,19 @@ static cl_int CL_API_CALL clEnqueueUnmapMemObject_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueUnmapMemObject_shutdown(
+    cl_command_queue command_queue,
+    cl_mem memobj,
+    void* mapped_ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2377,6 +2986,22 @@ static cl_int CL_API_CALL clEnqueueNDRangeKernel_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueNDRangeKernel_shutdown(
+    cl_command_queue command_queue,
+    cl_kernel kernel,
+    cl_uint work_dim,
+    const size_t* global_work_offset,
+    const size_t* global_work_size,
+    const size_t* local_work_size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2450,6 +3075,23 @@ static cl_int CL_API_CALL clEnqueueNativeKernel_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueNativeKernel_shutdown(
+    cl_command_queue command_queue,
+    void (CL_CALLBACK* user_func)(void*),
+    void* args,
+    size_t cb_args,
+    cl_uint num_mem_objects,
+    const cl_mem* mem_list,
+    const void** args_mem_loc,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetCommandQueueProperty(
@@ -2487,6 +3129,17 @@ static cl_int CL_API_CALL clSetCommandQueueProperty_disp(
         properties,
         enable,
         old_properties);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetCommandQueueProperty_shutdown(
+    cl_command_queue command_queue,
+    cl_command_queue_properties properties,
+    cl_bool enable,
+    cl_command_queue_properties* old_properties)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2547,6 +3200,21 @@ static cl_mem CL_API_CALL clCreateImage2D_disp(
         image_row_pitch,
         host_ptr,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateImage2D_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    const cl_image_format* image_format,
+    size_t image_width,
+    size_t image_height,
+    size_t image_row_pitch,
+    void* host_ptr,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2620,6 +3288,23 @@ static cl_mem CL_API_CALL clCreateImage3D_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateImage3D_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    const cl_image_format* image_format,
+    size_t image_width,
+    size_t image_height,
+    size_t image_depth,
+    size_t image_row_pitch,
+    size_t image_slice_pitch,
+    void* host_ptr,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarker(
@@ -2647,6 +3332,15 @@ static cl_int CL_API_CALL clEnqueueMarker_disp(
     return command_queue->dispatch->clEnqueueMarker(
         command_queue,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueMarker_shutdown(
+    cl_command_queue command_queue,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2685,6 +3379,16 @@ static cl_int CL_API_CALL clEnqueueWaitForEvents_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueWaitForEvents_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_events,
+    const cl_event* event_list)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrier(
@@ -2710,6 +3414,14 @@ static cl_int CL_API_CALL clEnqueueBarrier_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueBarrier_shutdown(
+    cl_command_queue command_queue)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clUnloadCompiler(
@@ -2730,6 +3442,14 @@ static cl_int CL_API_CALL clUnloadCompiler_disp(
 {
     // Nothing!
     return CL_SUCCESS;
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clUnloadCompiler_shutdown(
+    void )
+{
+    // Nothing!
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2780,6 +3500,17 @@ static cl_command_queue CL_API_CALL clCreateCommandQueue_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_command_queue CL_API_CALL clCreateCommandQueue_shutdown(
+    cl_context context,
+    cl_device_id device,
+    cl_command_queue_properties properties,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_sampler CL_API_CALL clCreateSampler(
@@ -2822,6 +3553,18 @@ static cl_sampler CL_API_CALL clCreateSampler_disp(
         addressing_mode,
         filter_mode,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_sampler CL_API_CALL clCreateSampler_shutdown(
+    cl_context context,
+    cl_bool normalized_coords,
+    cl_addressing_mode addressing_mode,
+    cl_filter_mode filter_mode,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -2870,6 +3613,18 @@ static cl_int CL_API_CALL clEnqueueTask_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueTask_shutdown(
+    cl_command_queue command_queue,
+    cl_kernel kernel,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_mem CL_API_CALL clCreateSubBuffer(
@@ -2915,6 +3670,18 @@ static cl_mem CL_API_CALL clCreateSubBuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateSubBuffer_shutdown(
+    cl_mem buffer,
+    cl_mem_flags flags,
+    cl_buffer_create_type buffer_create_type,
+    const void* buffer_create_info,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorCallback(
@@ -2950,6 +3717,16 @@ static cl_int CL_API_CALL clSetMemObjectDestructorCallback_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetMemObjectDestructorCallback_shutdown(
+    cl_mem memobj,
+    void (CL_CALLBACK* pfn_notify)(cl_mem memobj, void* user_data),
+    void* user_data)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_event CL_API_CALL clCreateUserEvent(
@@ -2980,6 +3757,15 @@ static cl_event CL_API_CALL clCreateUserEvent_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_event CL_API_CALL clCreateUserEvent_shutdown(
+    cl_context context,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetUserEventStatus(
@@ -3007,6 +3793,15 @@ static cl_int CL_API_CALL clSetUserEventStatus_disp(
     return event->dispatch->clSetUserEventStatus(
         event,
         execution_status);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetUserEventStatus_shutdown(
+    cl_event event,
+    cl_int execution_status)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3047,6 +3842,17 @@ static cl_int CL_API_CALL clSetEventCallback_disp(
         command_exec_callback_type,
         pfn_notify,
         user_data);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetEventCallback_shutdown(
+    cl_event event,
+    cl_int command_exec_callback_type,
+    void (CL_CALLBACK* pfn_notify)(cl_event event, cl_int event_command_status, void *user_data),
+    void* user_data)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3140,6 +3946,27 @@ static cl_int CL_API_CALL clEnqueueReadBufferRect_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReadBufferRect_shutdown(
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    cl_bool blocking_read,
+    const size_t* buffer_origin,
+    const size_t* host_origin,
+    const size_t* region,
+    size_t buffer_row_pitch,
+    size_t buffer_slice_pitch,
+    size_t host_row_pitch,
+    size_t host_slice_pitch,
+    void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteBufferRect(
@@ -3230,6 +4057,27 @@ static cl_int CL_API_CALL clEnqueueWriteBufferRect_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueWriteBufferRect_shutdown(
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    cl_bool blocking_write,
+    const size_t* buffer_origin,
+    const size_t* host_origin,
+    const size_t* region,
+    size_t buffer_row_pitch,
+    size_t buffer_slice_pitch,
+    size_t host_row_pitch,
+    size_t host_slice_pitch,
+    const void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueCopyBufferRect(
@@ -3315,6 +4163,26 @@ static cl_int CL_API_CALL clEnqueueCopyBufferRect_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueCopyBufferRect_shutdown(
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_buffer,
+    const size_t* src_origin,
+    const size_t* dst_origin,
+    const size_t* region,
+    size_t src_row_pitch,
+    size_t src_slice_pitch,
+    size_t dst_row_pitch,
+    size_t dst_slice_pitch,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clCreateSubDevices(
@@ -3360,6 +4228,18 @@ static cl_int CL_API_CALL clCreateSubDevices_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clCreateSubDevices_shutdown(
+    cl_device_id in_device,
+    const cl_device_partition_property* properties,
+    cl_uint num_devices,
+    cl_device_id* out_devices,
+    cl_uint* num_devices_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clRetainDevice(
@@ -3385,6 +4265,14 @@ static cl_int CL_API_CALL clRetainDevice_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainDevice_shutdown(
+    cl_device_id device)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseDevice(
@@ -3407,6 +4295,14 @@ static cl_int CL_API_CALL clReleaseDevice_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(device, CL_INVALID_DEVICE);
     return device->dispatch->clReleaseDevice(
         device);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseDevice_shutdown(
+    cl_device_id device)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3460,6 +4356,19 @@ static cl_mem CL_API_CALL clCreateImage_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateImage_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    const cl_image_format* image_format,
+    const cl_image_desc* image_desc,
+    void* host_ptr,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBuiltInKernels(
@@ -3502,6 +4411,18 @@ static cl_program CL_API_CALL clCreateProgramWithBuiltInKernels_disp(
         device_list,
         kernel_names,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_program CL_API_CALL clCreateProgramWithBuiltInKernels_shutdown(
+    cl_context context,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const char* kernel_names,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3570,6 +4491,22 @@ static cl_int CL_API_CALL clCompileProgram_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clCompileProgram_shutdown(
+    cl_program program,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const char* options,
+    cl_uint num_input_headers,
+    const cl_program* input_headers,
+    const char** header_include_names,
+    void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+    void* user_data)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_program CL_API_CALL clLinkProgram(
@@ -3635,6 +4572,22 @@ static cl_program CL_API_CALL clLinkProgram_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_program CL_API_CALL clLinkProgram_shutdown(
+    cl_context context,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const char* options,
+    cl_uint num_input_programs,
+    const cl_program* input_programs,
+    void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+    void* user_data,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clUnloadPlatformCompiler(
@@ -3657,6 +4610,14 @@ static cl_int CL_API_CALL clUnloadPlatformCompiler_disp(
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);
     return platform->dispatch->clUnloadPlatformCompiler(
         platform);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clUnloadPlatformCompiler_shutdown(
+    cl_platform_id platform)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3707,6 +4668,19 @@ static cl_int CL_API_CALL clGetKernelArgInfo_disp(
         param_value_size,
         param_value,
         param_value_size_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetKernelArgInfo_shutdown(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    cl_kernel_arg_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3775,6 +4749,22 @@ static cl_int CL_API_CALL clEnqueueFillBuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueFillBuffer_shutdown(
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    const void* pattern,
+    size_t pattern_size,
+    size_t offset,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueFillImage(
@@ -3835,6 +4825,21 @@ static cl_int CL_API_CALL clEnqueueFillImage_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueFillImage_shutdown(
+    cl_command_queue command_queue,
+    cl_mem image,
+    const void* fill_color,
+    const size_t* origin,
+    const size_t* region,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemObjects(
@@ -3890,6 +4895,20 @@ static cl_int CL_API_CALL clEnqueueMigrateMemObjects_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueMigrateMemObjects_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_mem_objects,
+    const cl_mem* mem_objects,
+    cl_mem_migration_flags flags,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMarkerWithWaitList(
@@ -3930,6 +4949,17 @@ static cl_int CL_API_CALL clEnqueueMarkerWithWaitList_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueMarkerWithWaitList_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueBarrierWithWaitList(
@@ -3967,6 +4997,17 @@ static cl_int CL_API_CALL clEnqueueBarrierWithWaitList_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueBarrierWithWaitList_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4015,6 +5056,17 @@ static cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties_disp(
         device,
         properties,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties_shutdown(
+    cl_context context,
+    cl_device_id device,
+    const cl_queue_properties* properties,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4068,6 +5120,19 @@ static cl_mem CL_API_CALL clCreatePipe_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreatePipe_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_uint pipe_packet_size,
+    cl_uint pipe_max_packets,
+    const cl_pipe_properties* properties,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetPipeInfo(
@@ -4113,6 +5178,18 @@ static cl_int CL_API_CALL clGetPipeInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetPipeInfo_shutdown(
+    cl_mem pipe,
+    cl_pipe_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY void* CL_API_CALL clSVMAlloc(
@@ -4153,6 +5230,17 @@ static void* CL_API_CALL clSVMAlloc_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static void* CL_API_CALL clSVMAlloc_shutdown(
+    cl_context context,
+    cl_svm_mem_flags flags,
+    size_t size,
+    cl_uint alignment)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY void CL_API_CALL clSVMFree(
@@ -4183,6 +5271,15 @@ static void CL_API_CALL clSVMFree_disp(
     context->dispatch->clSVMFree(
         context,
         svm_pointer);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static void CL_API_CALL clSVMFree_shutdown(
+    cl_context context,
+    void* svm_pointer)
+{
+    // Nothing!
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4221,6 +5318,16 @@ static cl_sampler CL_API_CALL clCreateSamplerWithProperties_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_sampler CL_API_CALL clCreateSamplerWithProperties_shutdown(
+    cl_context context,
+    const cl_sampler_properties* sampler_properties,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer(
@@ -4253,6 +5360,16 @@ static cl_int CL_API_CALL clSetKernelArgSVMPointer_disp(
         kernel,
         arg_index,
         arg_value);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetKernelArgSVMPointer_shutdown(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    const void* arg_value)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4293,6 +5410,17 @@ static cl_int CL_API_CALL clSetKernelExecInfo_disp(
         param_name,
         param_value_size,
         param_value);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetKernelExecInfo_shutdown(
+    cl_kernel kernel,
+    cl_kernel_exec_info param_name,
+    size_t param_value_size,
+    const void* param_value)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4356,6 +5484,21 @@ static cl_int CL_API_CALL clEnqueueSVMFree_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueSVMFree_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_svm_pointers,
+    void* svm_pointers[],
+    void (CL_CALLBACK* pfn_free_func)(cl_command_queue queue, cl_uint num_svm_pointers, void* svm_pointers[], void* user_data),
+    void* user_data,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMemcpy(
@@ -4413,6 +5556,21 @@ static cl_int CL_API_CALL clEnqueueSVMMemcpy_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueSVMMemcpy_shutdown(
+    cl_command_queue command_queue,
+    cl_bool blocking_copy,
+    void* dst_ptr,
+    const void* src_ptr,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4476,6 +5634,21 @@ static cl_int CL_API_CALL clEnqueueSVMMemFill_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueSVMMemFill_shutdown(
+    cl_command_queue command_queue,
+    void* svm_ptr,
+    const void* pattern,
+    size_t pattern_size,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMap(
@@ -4536,6 +5709,21 @@ static cl_int CL_API_CALL clEnqueueSVMMap_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueSVMMap_shutdown(
+    cl_command_queue command_queue,
+    cl_bool blocking_map,
+    cl_map_flags flags,
+    void* svm_ptr,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMUnmap(
@@ -4581,6 +5769,18 @@ static cl_int CL_API_CALL clEnqueueSVMUnmap_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueSVMUnmap_shutdown(
+    cl_command_queue command_queue,
+    void* svm_ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetDefaultDeviceCommandQueue(
@@ -4613,6 +5813,16 @@ static cl_int CL_API_CALL clSetDefaultDeviceCommandQueue_disp(
         context,
         device,
         command_queue);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetDefaultDeviceCommandQueue_shutdown(
+    cl_context context,
+    cl_device_id device,
+    cl_command_queue command_queue)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4651,6 +5861,16 @@ static cl_int CL_API_CALL clGetDeviceAndHostTimer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetDeviceAndHostTimer_shutdown(
+    cl_device_id device,
+    cl_ulong* device_timestamp,
+    cl_ulong* host_timestamp)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetHostTimer(
@@ -4678,6 +5898,15 @@ static cl_int CL_API_CALL clGetHostTimer_disp(
     return device->dispatch->clGetHostTimer(
         device,
         host_timestamp);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetHostTimer_shutdown(
+    cl_device_id device,
+    cl_ulong* host_timestamp)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4721,6 +5950,17 @@ static cl_program CL_API_CALL clCreateProgramWithIL_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_program CL_API_CALL clCreateProgramWithIL_shutdown(
+    cl_context context,
+    const void* il,
+    size_t length,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_kernel CL_API_CALL clCloneKernel(
@@ -4748,6 +5988,15 @@ static cl_kernel CL_API_CALL clCloneKernel_disp(
     return source_kernel->dispatch->clCloneKernel(
         source_kernel,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_kernel CL_API_CALL clCloneKernel_shutdown(
+    cl_kernel source_kernel,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -4811,6 +6060,21 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfo_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetKernelSubGroupInfo_shutdown(
+    cl_kernel kernel,
+    cl_device_id device,
+    cl_kernel_sub_group_info param_name,
+    size_t input_value_size,
+    const void* input_value,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMigrateMem(
@@ -4871,6 +6135,21 @@ static cl_int CL_API_CALL clEnqueueSVMMigrateMem_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueSVMMigrateMem_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_svm_pointers,
+    const void** svm_pointers,
+    const size_t* sizes,
+    cl_mem_migration_flags flags,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetProgramSpecializationConstant(
@@ -4911,6 +6190,17 @@ static cl_int CL_API_CALL clSetProgramSpecializationConstant_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetProgramSpecializationConstant_shutdown(
+    cl_program program,
+    cl_uint spec_id,
+    size_t spec_size,
+    const void* spec_value)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetProgramReleaseCallback(
@@ -4946,6 +6236,16 @@ static cl_int CL_API_CALL clSetProgramReleaseCallback_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetProgramReleaseCallback_shutdown(
+    cl_program program,
+    void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+    void* user_data)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback(
@@ -4978,6 +6278,16 @@ static cl_int CL_API_CALL clSetContextDestructorCallback_disp(
         context,
         pfn_notify,
         user_data);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clSetContextDestructorCallback_shutdown(
+    cl_context context,
+    void (CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
+    void* user_data)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -5028,6 +6338,19 @@ static cl_mem CL_API_CALL clCreateBufferWithProperties_disp(
         size,
         host_ptr,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateBufferWithProperties_shutdown(
+    cl_context context,
+    const cl_mem_properties* properties,
+    cl_mem_flags flags,
+    size_t size,
+    void* host_ptr,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -5083,6 +6406,20 @@ static cl_mem CL_API_CALL clCreateImageWithProperties_disp(
         image_desc,
         host_ptr,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateImageWithProperties_shutdown(
+    cl_context context,
+    const cl_mem_properties* properties,
+    cl_mem_flags flags,
+    const cl_image_format* image_format,
+    const cl_image_desc* image_desc,
+    void* host_ptr,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6909,7 +8246,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clEnqueueReleaseGLObjects_disp,
     &clGetGLContextInfoKHR_disp,
 
-  /* cl_khr_d3d10_sharing */
+    /* cl_khr_d3d10_sharing */
 #if defined(_WIN32)
     &clGetDeviceIDsFromD3D10KHR_disp,
     &clCreateFromD3D10BufferKHR_disp,
@@ -6926,7 +8263,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     NULL,
 #endif
 
-  /* OpenCL 1.1 */
+    /* OpenCL 1.1 */
     &clSetEventCallback_disp,
     &clCreateSubBuffer_disp,
     &clSetMemObjectDestructorCallback_disp,
@@ -6936,15 +8273,15 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clEnqueueWriteBufferRect_disp,
     &clEnqueueCopyBufferRect_disp,
 
-  /* cl_ext_device_fission */
+    /* cl_ext_device_fission */
     &clCreateSubDevicesEXT_disp,
     &clRetainDeviceEXT_disp,
     &clReleaseDeviceEXT_disp,
 
-  /* cl_khr_gl_event */
+    /* cl_khr_gl_event */
     &clCreateEventFromGLsyncKHR_disp,
 
-  /* OpenCL 1.2 */
+    /* OpenCL 1.2 */
     &clCreateSubDevices_disp,
     &clRetainDevice_disp,
     &clReleaseDevice_disp,
@@ -6962,7 +8299,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clGetExtensionFunctionAddressForPlatform_disp,
     &clCreateFromGLTexture_disp,
 
-  /* cl_khr_d3d11_sharing */
+    /* cl_khr_d3d11_sharing */
 #if defined(_WIN32)
     &clGetDeviceIDsFromD3D11KHR_disp,
     &clCreateFromD3D11BufferKHR_disp,
@@ -6981,7 +8318,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     NULL,
 #endif
 
-  /* cl_khr_dx9_media_sharing */
+    /* cl_khr_dx9_media_sharing */
 #if defined(_WIN32)
     &clGetDeviceIDsFromDX9MediaAdapterKHR_disp,
     &clEnqueueAcquireDX9MediaSurfacesKHR_disp,
@@ -6992,15 +8329,15 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     NULL,
 #endif
 
-  /* cl_khr_egl_image */
+    /* cl_khr_egl_image */
     &clCreateFromEGLImageKHR_disp,
     &clEnqueueAcquireEGLObjectsKHR_disp,
     &clEnqueueReleaseEGLObjectsKHR_disp,
 
-  /* cl_khr_egl_event */
+    /* cl_khr_egl_event */
     &clCreateEventFromEGLSyncKHR_disp,
 
-  /* OpenCL 2.0 */
+    /* OpenCL 2.0 */
     &clCreateCommandQueueWithProperties_disp,
     &clCreatePipe_disp,
     &clGetPipeInfo_disp,
@@ -7015,10 +8352,10 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clSetKernelArgSVMPointer_disp,
     &clSetKernelExecInfo_disp,
 
-  /* cl_khr_sub_groups */
+    /* cl_khr_sub_groups */
     &clGetKernelSubGroupInfoKHR_disp,
 
-  /* OpenCL 2.1 */
+    /* OpenCL 2.1 */
     &clCloneKernel_disp,
     &clCreateProgramWithIL_disp,
     &clEnqueueSVMMigrateMem_disp,
@@ -7027,14 +8364,14 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clGetKernelSubGroupInfo_disp,
     &clSetDefaultDeviceCommandQueue_disp,
 
-  /* OpenCL 2.2 */
+    /* OpenCL 2.2 */
     &clSetProgramReleaseCallback_disp,
     &clSetProgramSpecializationConstant_disp,
 
-  /* OpenCL 3.0 */
+    /* OpenCL 3.0 */
     &clCreateBufferWithProperties_disp,
     &clCreateImageWithProperties_disp,
-    &clSetContextDestructorCallback_disp
+    &clSetContextDestructorCallback_disp,
 };
 #endif // defined(CL_ENABLE_LAYERS)
 

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -32,6 +32,16 @@ extern cl_int CL_API_CALL clGetPlatformIDs_disp(
     cl_uint* num_platforms) CL_API_SUFFIX__VERSION_1_0;
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetPlatformIDs_shutdown(
+    cl_uint num_entries,
+    cl_platform_id* platforms,
+    cl_uint* num_platforms)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_int CL_API_CALL clGetPlatformInfo(
@@ -3449,7 +3459,7 @@ static cl_int CL_API_CALL clUnloadCompiler_disp(
 static cl_int CL_API_CALL clUnloadCompiler_shutdown(
     void )
 {
-    // Nothing!
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -3458,6 +3468,14 @@ static cl_int CL_API_CALL clUnloadCompiler_shutdown(
 #if defined(CL_ENABLE_LAYERS)
 extern void* CL_API_CALL clGetExtensionFunctionAddress_disp(
     const char* func_name) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static void* CL_API_CALL clGetExtensionFunctionAddress_shutdown(
+    const char* func_name)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
+}
 #endif // defined(CL_ENABLE_LAYERS)
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5019,6 +5037,15 @@ extern void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_disp(
     const char* func_name) CL_API_SUFFIX__VERSION_1_2;
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_shutdown(
+    cl_platform_id platform,
+    const char* func_name)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties(
@@ -6453,6 +6480,14 @@ static cl_int CL_API_CALL clReleaseDeviceEXT_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clReleaseDeviceEXT_shutdown(
+    cl_device_id device)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_ext_device_fission
 
@@ -6478,6 +6513,14 @@ static cl_int CL_API_CALL clRetainDeviceEXT_disp(
     KHR_ICD_VALIDATE_POINTER_RETURN_ERROR(device->dispatch->clRetainDeviceEXT);
     return device->dispatch->clRetainDeviceEXT(
         device);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clRetainDeviceEXT_shutdown(
+    cl_device_id device)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6526,6 +6569,18 @@ static cl_int CL_API_CALL clCreateSubDevicesEXT_disp(
         num_entries,
         out_devices,
         num_devices);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clCreateSubDevicesEXT_shutdown(
+    cl_device_id in_device,
+    const cl_device_partition_property_ext* properties,
+    cl_uint num_entries,
+    cl_device_id* out_devices,
+    cl_uint* num_devices)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6590,6 +6645,20 @@ static cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR_shutdown(
+    cl_platform_id platform,
+    cl_d3d10_device_source_khr d3d_device_source,
+    void* d3d_object,
+    cl_d3d10_device_set_khr d3d_device_set,
+    cl_uint num_entries,
+    cl_device_id* devices,
+    cl_uint* num_devices)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_d3d10_sharing
 
@@ -6630,6 +6699,17 @@ static cl_mem CL_API_CALL clCreateFromD3D10BufferKHR_disp(
         flags,
         resource,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromD3D10BufferKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    ID3D10Buffer* resource,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6681,6 +6761,18 @@ static cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    ID3D10Texture2D* resource,
+    UINT subresource,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_d3d10_sharing
 
@@ -6726,6 +6818,18 @@ static cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR_disp(
         resource,
         subresource,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    ID3D10Texture3D* resource,
+    UINT subresource,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6782,6 +6886,19 @@ static cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_d3d10_sharing
 
@@ -6832,6 +6949,19 @@ static cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6897,6 +7027,20 @@ static cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR_shutdown(
+    cl_platform_id platform,
+    cl_d3d11_device_source_khr d3d_device_source,
+    void* d3d_object,
+    cl_d3d11_device_set_khr d3d_device_set,
+    cl_uint num_entries,
+    cl_device_id* devices,
+    cl_uint* num_devices)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_d3d11_sharing
 
@@ -6937,6 +7081,17 @@ static cl_mem CL_API_CALL clCreateFromD3D11BufferKHR_disp(
         flags,
         resource,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromD3D11BufferKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    ID3D11Buffer* resource,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -6988,6 +7143,18 @@ static cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    ID3D11Texture2D* resource,
+    UINT subresource,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_d3d11_sharing
 
@@ -7033,6 +7200,18 @@ static cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR_disp(
         resource,
         subresource,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    ID3D11Texture3D* resource,
+    UINT subresource,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7089,6 +7268,19 @@ static cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_d3d11_sharing
 
@@ -7139,6 +7331,19 @@ static cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7209,6 +7414,21 @@ static cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR_shutdown(
+    cl_platform_id platform,
+    cl_uint num_media_adapters,
+    cl_dx9_media_adapter_type_khr* media_adapter_type,
+    void* media_adapters,
+    cl_dx9_media_adapter_set_khr media_adapter_set,
+    cl_uint num_entries,
+    cl_device_id* devices,
+    cl_uint* num_devices)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_dx9_media_sharing
 
@@ -7259,6 +7479,19 @@ static cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR_disp(
         surface_info,
         plane,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_dx9_media_adapter_type_khr adapter_type,
+    void* surface_info,
+    cl_uint plane,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7315,6 +7548,19 @@ static cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_dx9_media_sharing
 
@@ -7368,6 +7614,19 @@ static cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 #endif // defined(_WIN32)
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7410,6 +7669,17 @@ static cl_event CL_API_CALL clCreateEventFromEGLSyncKHR_disp(
         sync,
         display,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_event CL_API_CALL clCreateEventFromEGLSyncKHR_shutdown(
+    cl_context context,
+    CLeglSyncKHR sync,
+    CLeglDisplayKHR display,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7467,6 +7737,19 @@ static cl_mem CL_API_CALL clCreateFromEGLImageKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromEGLImageKHR_shutdown(
+    cl_context context,
+    CLeglDisplayKHR egldisplay,
+    CLeglImageKHR eglimage,
+    cl_mem_flags flags,
+    const cl_egl_image_properties_khr* properties,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_egl_image
 
@@ -7517,6 +7800,19 @@ static cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueAcquireEGLObjectsKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7573,6 +7869,19 @@ static cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReleaseEGLObjectsKHR_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_event
@@ -7609,6 +7918,16 @@ static cl_event CL_API_CALL clCreateEventFromGLsyncKHR_disp(
         context,
         sync,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_event CL_API_CALL clCreateEventFromGLsyncKHR_shutdown(
+    cl_context context,
+    cl_GLsync sync,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7665,6 +7984,18 @@ static cl_int CL_API_CALL clGetGLContextInfoKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetGLContextInfoKHR_shutdown(
+    const cl_context_properties* properties,
+    cl_gl_context_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_sharing
 
@@ -7705,6 +8036,17 @@ static cl_mem CL_API_CALL clCreateFromGLBuffer_disp(
         flags,
         bufobj,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromGLBuffer_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_GLuint bufobj,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7761,6 +8103,19 @@ static cl_mem CL_API_CALL clCreateFromGLTexture_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromGLTexture_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_GLenum target,
+    cl_GLint miplevel,
+    cl_GLuint texture,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_sharing
 
@@ -7804,6 +8159,17 @@ static cl_mem CL_API_CALL clCreateFromGLRenderbuffer_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromGLRenderbuffer_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_GLuint renderbuffer,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_sharing
 
@@ -7839,6 +8205,16 @@ static cl_int CL_API_CALL clGetGLObjectInfo_disp(
         memobj,
         gl_object_type,
         gl_object_name);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetGLObjectInfo_shutdown(
+    cl_mem memobj,
+    cl_gl_object_type* gl_object_type,
+    cl_GLuint* gl_object_name)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7887,6 +8263,18 @@ static cl_int CL_API_CALL clGetGLTextureInfo_disp(
         param_value_size,
         param_value,
         param_value_size_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetGLTextureInfo_shutdown(
+    cl_mem memobj,
+    cl_gl_texture_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -7943,6 +8331,19 @@ static cl_int CL_API_CALL clEnqueueAcquireGLObjects_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueAcquireGLObjects_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_sharing
 
@@ -7993,6 +8394,19 @@ static cl_int CL_API_CALL clEnqueueReleaseGLObjects_disp(
         num_events_in_wait_list,
         event_wait_list,
         event);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clEnqueueReleaseGLObjects_shutdown(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem* mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -8049,6 +8463,19 @@ static cl_mem CL_API_CALL clCreateFromGLTexture2D_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromGLTexture2D_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_GLenum target,
+    cl_GLint miplevel,
+    cl_GLuint texture,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_gl_sharing
 
@@ -8099,6 +8526,19 @@ static cl_mem CL_API_CALL clCreateFromGLTexture3D_disp(
         miplevel,
         texture,
         errcode_ret);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
+#if defined(CL_ENABLE_LAYERS)
+static cl_mem CL_API_CALL clCreateFromGLTexture3D_shutdown(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_GLenum target,
+    cl_GLint miplevel,
+    cl_GLuint texture,
+    cl_int* errcode_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
@@ -8166,9 +8606,25 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_disp(
 }
 #endif // defined(CL_ENABLE_LAYERS)
 
+#if defined(CL_ENABLE_LAYERS)
+static cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_shutdown(
+    cl_kernel in_kernel,
+    cl_device_id in_device,
+    cl_kernel_sub_group_info param_name,
+    size_t input_value_size,
+    const void* input_value,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 #if defined(CL_ENABLE_LAYERS)
+
 struct _cl_icd_dispatch khrActualDispatch = {
     &clGetPlatformIDs_disp,
     &clGetPlatformInfo_disp,
@@ -8373,6 +8829,212 @@ struct _cl_icd_dispatch khrActualDispatch = {
     &clCreateImageWithProperties_disp,
     &clSetContextDestructorCallback_disp,
 };
+
+struct _cl_icd_dispatch khrShutdownDispatch = {
+    &clGetPlatformIDs_shutdown,
+    &clGetPlatformInfo_shutdown,
+    &clGetDeviceIDs_shutdown,
+    &clGetDeviceInfo_shutdown,
+    &clCreateContext_shutdown,
+    &clCreateContextFromType_shutdown,
+    &clRetainContext_shutdown,
+    &clReleaseContext_shutdown,
+    &clGetContextInfo_shutdown,
+    &clCreateCommandQueue_shutdown,
+    &clRetainCommandQueue_shutdown,
+    &clReleaseCommandQueue_shutdown,
+    &clGetCommandQueueInfo_shutdown,
+    &clSetCommandQueueProperty_shutdown,
+    &clCreateBuffer_shutdown,
+    &clCreateImage2D_shutdown,
+    &clCreateImage3D_shutdown,
+    &clRetainMemObject_shutdown,
+    &clReleaseMemObject_shutdown,
+    &clGetSupportedImageFormats_shutdown,
+    &clGetMemObjectInfo_shutdown,
+    &clGetImageInfo_shutdown,
+    &clCreateSampler_shutdown,
+    &clRetainSampler_shutdown,
+    &clReleaseSampler_shutdown,
+    &clGetSamplerInfo_shutdown,
+    &clCreateProgramWithSource_shutdown,
+    &clCreateProgramWithBinary_shutdown,
+    &clRetainProgram_shutdown,
+    &clReleaseProgram_shutdown,
+    &clBuildProgram_shutdown,
+    &clUnloadCompiler_shutdown,
+    &clGetProgramInfo_shutdown,
+    &clGetProgramBuildInfo_shutdown,
+    &clCreateKernel_shutdown,
+    &clCreateKernelsInProgram_shutdown,
+    &clRetainKernel_shutdown,
+    &clReleaseKernel_shutdown,
+    &clSetKernelArg_shutdown,
+    &clGetKernelInfo_shutdown,
+    &clGetKernelWorkGroupInfo_shutdown,
+    &clWaitForEvents_shutdown,
+    &clGetEventInfo_shutdown,
+    &clRetainEvent_shutdown,
+    &clReleaseEvent_shutdown,
+    &clGetEventProfilingInfo_shutdown,
+    &clFlush_shutdown,
+    &clFinish_shutdown,
+    &clEnqueueReadBuffer_shutdown,
+    &clEnqueueWriteBuffer_shutdown,
+    &clEnqueueCopyBuffer_shutdown,
+    &clEnqueueReadImage_shutdown,
+    &clEnqueueWriteImage_shutdown,
+    &clEnqueueCopyImage_shutdown,
+    &clEnqueueCopyImageToBuffer_shutdown,
+    &clEnqueueCopyBufferToImage_shutdown,
+    &clEnqueueMapBuffer_shutdown,
+    &clEnqueueMapImage_shutdown,
+    &clEnqueueUnmapMemObject_shutdown,
+    &clEnqueueNDRangeKernel_shutdown,
+    &clEnqueueTask_shutdown,
+    &clEnqueueNativeKernel_shutdown,
+    &clEnqueueMarker_shutdown,
+    &clEnqueueWaitForEvents_shutdown,
+    &clEnqueueBarrier_shutdown,
+    &clGetExtensionFunctionAddress_shutdown,
+    &clCreateFromGLBuffer_shutdown,
+    &clCreateFromGLTexture2D_shutdown,
+    &clCreateFromGLTexture3D_shutdown,
+    &clCreateFromGLRenderbuffer_shutdown,
+    &clGetGLObjectInfo_shutdown,
+    &clGetGLTextureInfo_shutdown,
+    &clEnqueueAcquireGLObjects_shutdown,
+    &clEnqueueReleaseGLObjects_shutdown,
+    &clGetGLContextInfoKHR_shutdown,
+
+    /* cl_khr_d3d10_sharing */
+#if defined(_WIN32)
+    &clGetDeviceIDsFromD3D10KHR_shutdown,
+    &clCreateFromD3D10BufferKHR_shutdown,
+    &clCreateFromD3D10Texture2DKHR_shutdown,
+    &clCreateFromD3D10Texture3DKHR_shutdown,
+    &clEnqueueAcquireD3D10ObjectsKHR_shutdown,
+    &clEnqueueReleaseD3D10ObjectsKHR_shutdown,
+#else
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+#endif
+
+    /* OpenCL 1.1 */
+    &clSetEventCallback_shutdown,
+    &clCreateSubBuffer_shutdown,
+    &clSetMemObjectDestructorCallback_shutdown,
+    &clCreateUserEvent_shutdown,
+    &clSetUserEventStatus_shutdown,
+    &clEnqueueReadBufferRect_shutdown,
+    &clEnqueueWriteBufferRect_shutdown,
+    &clEnqueueCopyBufferRect_shutdown,
+
+    /* cl_ext_device_fission */
+    &clCreateSubDevicesEXT_shutdown,
+    &clRetainDeviceEXT_shutdown,
+    &clReleaseDeviceEXT_shutdown,
+
+    /* cl_khr_gl_event */
+    &clCreateEventFromGLsyncKHR_shutdown,
+
+    /* OpenCL 1.2 */
+    &clCreateSubDevices_shutdown,
+    &clRetainDevice_shutdown,
+    &clReleaseDevice_shutdown,
+    &clCreateImage_shutdown,
+    &clCreateProgramWithBuiltInKernels_shutdown,
+    &clCompileProgram_shutdown,
+    &clLinkProgram_shutdown,
+    &clUnloadPlatformCompiler_shutdown,
+    &clGetKernelArgInfo_shutdown,
+    &clEnqueueFillBuffer_shutdown,
+    &clEnqueueFillImage_shutdown,
+    &clEnqueueMigrateMemObjects_shutdown,
+    &clEnqueueMarkerWithWaitList_shutdown,
+    &clEnqueueBarrierWithWaitList_shutdown,
+    &clGetExtensionFunctionAddressForPlatform_shutdown,
+    &clCreateFromGLTexture_shutdown,
+
+    /* cl_khr_d3d11_sharing */
+#if defined(_WIN32)
+    &clGetDeviceIDsFromD3D11KHR_shutdown,
+    &clCreateFromD3D11BufferKHR_shutdown,
+    &clCreateFromD3D11Texture2DKHR_shutdown,
+    &clCreateFromD3D11Texture3DKHR_shutdown,
+    &clCreateFromDX9MediaSurfaceKHR_shutdown,
+    &clEnqueueAcquireD3D11ObjectsKHR_shutdown,
+    &clEnqueueReleaseD3D11ObjectsKHR_shutdown,
+#else
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+#endif
+
+    /* cl_khr_dx9_media_sharing */
+#if defined(_WIN32)
+    &clGetDeviceIDsFromDX9MediaAdapterKHR_shutdown,
+    &clEnqueueAcquireDX9MediaSurfacesKHR_shutdown,
+    &clEnqueueReleaseDX9MediaSurfacesKHR_shutdown,
+#else
+    NULL,
+    NULL,
+    NULL,
+#endif
+
+    /* cl_khr_egl_image */
+    &clCreateFromEGLImageKHR_shutdown,
+    &clEnqueueAcquireEGLObjectsKHR_shutdown,
+    &clEnqueueReleaseEGLObjectsKHR_shutdown,
+
+    /* cl_khr_egl_event */
+    &clCreateEventFromEGLSyncKHR_shutdown,
+
+    /* OpenCL 2.0 */
+    &clCreateCommandQueueWithProperties_shutdown,
+    &clCreatePipe_shutdown,
+    &clGetPipeInfo_shutdown,
+    &clSVMAlloc_shutdown,
+    &clSVMFree_shutdown,
+    &clEnqueueSVMFree_shutdown,
+    &clEnqueueSVMMemcpy_shutdown,
+    &clEnqueueSVMMemFill_shutdown,
+    &clEnqueueSVMMap_shutdown,
+    &clEnqueueSVMUnmap_shutdown,
+    &clCreateSamplerWithProperties_shutdown,
+    &clSetKernelArgSVMPointer_shutdown,
+    &clSetKernelExecInfo_shutdown,
+
+    /* cl_khr_sub_groups */
+    &clGetKernelSubGroupInfoKHR_shutdown,
+
+    /* OpenCL 2.1 */
+    &clCloneKernel_shutdown,
+    &clCreateProgramWithIL_shutdown,
+    &clEnqueueSVMMigrateMem_shutdown,
+    &clGetDeviceAndHostTimer_shutdown,
+    &clGetHostTimer_shutdown,
+    &clGetKernelSubGroupInfo_shutdown,
+    &clSetDefaultDeviceCommandQueue_shutdown,
+
+    /* OpenCL 2.2 */
+    &clSetProgramReleaseCallback_shutdown,
+    &clSetProgramSpecializationConstant_shutdown,
+
+    /* OpenCL 3.0 */
+    &clCreateBufferWithProperties_shutdown,
+    &clCreateImageWithProperties_shutdown,
+    &clSetContextDestructorCallback_shutdown,
+};
+
 #endif // defined(CL_ENABLE_LAYERS)
 
 #ifdef __cplusplus

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -158,28 +158,6 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 %  endif
 
 %endfor
-#if defined(CL_ENABLE_LAYERS)
-static ${api.RetType} CL_API_CALL ${api.Name}_shutdown(
-%for i, param in enumerate(api.Params):
-%  if i < len(api.Params)-1:
-    ${param.Type} ${param.Name}${param.TypeEnd},
-%  else:
-    ${param.Type} ${param.Name}${param.TypeEnd})
-%  endif
-%endfor
-{
-%if api.Name == "clUnloadCompiler" or api.Name == "clSVMFree":
-    // Nothing!
-%elif api.Name == "clSVMAlloc" or api.Name == "clGetExtensionFunctionAddressForPlatform":
-    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
-%elif api.RetType in apihandles or api.RetType == "void*":
-    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
-%else:
-    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
-%endif
-}
-#endif // defined(CL_ENABLE_LAYERS)
-
 %else:
 
 #if defined(CL_ENABLE_LAYERS)
@@ -194,6 +172,28 @@ extern ${api.RetType} CL_API_CALL ${api.Name + "_disp"}(
 #endif // defined(CL_ENABLE_LAYERS)
 
 %endif
+#if defined(CL_ENABLE_LAYERS)
+static ${api.RetType} CL_API_CALL ${api.Name}_shutdown(
+%for i, param in enumerate(api.Params):
+%  if i < len(api.Params)-1:
+    ${param.Type} ${param.Name}${param.TypeEnd},
+%  else:
+    ${param.Type} ${param.Name}${param.TypeEnd})
+%  endif
+%endfor
+{
+%if api.Name in ["clSVMFree"]:
+    // Nothing!
+%elif api.Name in ["clSVMAlloc", "clGetExtensionFunctionAddress", "clGetExtensionFunctionAddressForPlatform"]:
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
+%elif api.RetType in apihandles or api.RetType == "void*":
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+%else:
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+%endif
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 %endfor
 %endfor
 <%
@@ -295,6 +295,24 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 
 %  endif
 %endfor
+#if defined(CL_ENABLE_LAYERS)
+static ${api.RetType} CL_API_CALL ${api.Name}_shutdown(
+%for i, param in enumerate(api.Params):
+%  if i < len(api.Params)-1:
+    ${param.Type} ${param.Name}${param.TypeEnd},
+%  else:
+    ${param.Type} ${param.Name}${param.TypeEnd})
+%  endif
+%endfor
+{
+%if api.RetType in apihandles:
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+%else:
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+%endif
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 %endfor
 %if extension in win32extensions:
 #endif // defined(_WIN32)

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -303,7 +303,8 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 ///////////////////////////////////////////////////////////////////////////////
 
 #if defined(CL_ENABLE_LAYERS)
-struct _cl_icd_dispatch khrMasterDispatch = {
+
+struct _cl_icd_dispatch khrActualDispatch = {
     &clGetPlatformIDs_disp,
     &clGetPlatformInfo_disp,
     &clGetDeviceIDs_disp,
@@ -507,6 +508,212 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clCreateImageWithProperties_disp,
     &clSetContextDestructorCallback_disp,
 };
+
+struct _cl_icd_dispatch khrShutdownDispatch = {
+    &clGetPlatformIDs_shutdown,
+    &clGetPlatformInfo_shutdown,
+    &clGetDeviceIDs_shutdown,
+    &clGetDeviceInfo_shutdown,
+    &clCreateContext_shutdown,
+    &clCreateContextFromType_shutdown,
+    &clRetainContext_shutdown,
+    &clReleaseContext_shutdown,
+    &clGetContextInfo_shutdown,
+    &clCreateCommandQueue_shutdown,
+    &clRetainCommandQueue_shutdown,
+    &clReleaseCommandQueue_shutdown,
+    &clGetCommandQueueInfo_shutdown,
+    &clSetCommandQueueProperty_shutdown,
+    &clCreateBuffer_shutdown,
+    &clCreateImage2D_shutdown,
+    &clCreateImage3D_shutdown,
+    &clRetainMemObject_shutdown,
+    &clReleaseMemObject_shutdown,
+    &clGetSupportedImageFormats_shutdown,
+    &clGetMemObjectInfo_shutdown,
+    &clGetImageInfo_shutdown,
+    &clCreateSampler_shutdown,
+    &clRetainSampler_shutdown,
+    &clReleaseSampler_shutdown,
+    &clGetSamplerInfo_shutdown,
+    &clCreateProgramWithSource_shutdown,
+    &clCreateProgramWithBinary_shutdown,
+    &clRetainProgram_shutdown,
+    &clReleaseProgram_shutdown,
+    &clBuildProgram_shutdown,
+    &clUnloadCompiler_shutdown,
+    &clGetProgramInfo_shutdown,
+    &clGetProgramBuildInfo_shutdown,
+    &clCreateKernel_shutdown,
+    &clCreateKernelsInProgram_shutdown,
+    &clRetainKernel_shutdown,
+    &clReleaseKernel_shutdown,
+    &clSetKernelArg_shutdown,
+    &clGetKernelInfo_shutdown,
+    &clGetKernelWorkGroupInfo_shutdown,
+    &clWaitForEvents_shutdown,
+    &clGetEventInfo_shutdown,
+    &clRetainEvent_shutdown,
+    &clReleaseEvent_shutdown,
+    &clGetEventProfilingInfo_shutdown,
+    &clFlush_shutdown,
+    &clFinish_shutdown,
+    &clEnqueueReadBuffer_shutdown,
+    &clEnqueueWriteBuffer_shutdown,
+    &clEnqueueCopyBuffer_shutdown,
+    &clEnqueueReadImage_shutdown,
+    &clEnqueueWriteImage_shutdown,
+    &clEnqueueCopyImage_shutdown,
+    &clEnqueueCopyImageToBuffer_shutdown,
+    &clEnqueueCopyBufferToImage_shutdown,
+    &clEnqueueMapBuffer_shutdown,
+    &clEnqueueMapImage_shutdown,
+    &clEnqueueUnmapMemObject_shutdown,
+    &clEnqueueNDRangeKernel_shutdown,
+    &clEnqueueTask_shutdown,
+    &clEnqueueNativeKernel_shutdown,
+    &clEnqueueMarker_shutdown,
+    &clEnqueueWaitForEvents_shutdown,
+    &clEnqueueBarrier_shutdown,
+    &clGetExtensionFunctionAddress_shutdown,
+    &clCreateFromGLBuffer_shutdown,
+    &clCreateFromGLTexture2D_shutdown,
+    &clCreateFromGLTexture3D_shutdown,
+    &clCreateFromGLRenderbuffer_shutdown,
+    &clGetGLObjectInfo_shutdown,
+    &clGetGLTextureInfo_shutdown,
+    &clEnqueueAcquireGLObjects_shutdown,
+    &clEnqueueReleaseGLObjects_shutdown,
+    &clGetGLContextInfoKHR_shutdown,
+
+    /* cl_khr_d3d10_sharing */
+#if defined(_WIN32)
+    &clGetDeviceIDsFromD3D10KHR_shutdown,
+    &clCreateFromD3D10BufferKHR_shutdown,
+    &clCreateFromD3D10Texture2DKHR_shutdown,
+    &clCreateFromD3D10Texture3DKHR_shutdown,
+    &clEnqueueAcquireD3D10ObjectsKHR_shutdown,
+    &clEnqueueReleaseD3D10ObjectsKHR_shutdown,
+#else
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+#endif
+
+    /* OpenCL 1.1 */
+    &clSetEventCallback_shutdown,
+    &clCreateSubBuffer_shutdown,
+    &clSetMemObjectDestructorCallback_shutdown,
+    &clCreateUserEvent_shutdown,
+    &clSetUserEventStatus_shutdown,
+    &clEnqueueReadBufferRect_shutdown,
+    &clEnqueueWriteBufferRect_shutdown,
+    &clEnqueueCopyBufferRect_shutdown,
+
+    /* cl_ext_device_fission */
+    &clCreateSubDevicesEXT_shutdown,
+    &clRetainDeviceEXT_shutdown,
+    &clReleaseDeviceEXT_shutdown,
+
+    /* cl_khr_gl_event */
+    &clCreateEventFromGLsyncKHR_shutdown,
+
+    /* OpenCL 1.2 */
+    &clCreateSubDevices_shutdown,
+    &clRetainDevice_shutdown,
+    &clReleaseDevice_shutdown,
+    &clCreateImage_shutdown,
+    &clCreateProgramWithBuiltInKernels_shutdown,
+    &clCompileProgram_shutdown,
+    &clLinkProgram_shutdown,
+    &clUnloadPlatformCompiler_shutdown,
+    &clGetKernelArgInfo_shutdown,
+    &clEnqueueFillBuffer_shutdown,
+    &clEnqueueFillImage_shutdown,
+    &clEnqueueMigrateMemObjects_shutdown,
+    &clEnqueueMarkerWithWaitList_shutdown,
+    &clEnqueueBarrierWithWaitList_shutdown,
+    &clGetExtensionFunctionAddressForPlatform_shutdown,
+    &clCreateFromGLTexture_shutdown,
+
+    /* cl_khr_d3d11_sharing */
+#if defined(_WIN32)
+    &clGetDeviceIDsFromD3D11KHR_shutdown,
+    &clCreateFromD3D11BufferKHR_shutdown,
+    &clCreateFromD3D11Texture2DKHR_shutdown,
+    &clCreateFromD3D11Texture3DKHR_shutdown,
+    &clCreateFromDX9MediaSurfaceKHR_shutdown,
+    &clEnqueueAcquireD3D11ObjectsKHR_shutdown,
+    &clEnqueueReleaseD3D11ObjectsKHR_shutdown,
+#else
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+#endif
+
+    /* cl_khr_dx9_media_sharing */
+#if defined(_WIN32)
+    &clGetDeviceIDsFromDX9MediaAdapterKHR_shutdown,
+    &clEnqueueAcquireDX9MediaSurfacesKHR_shutdown,
+    &clEnqueueReleaseDX9MediaSurfacesKHR_shutdown,
+#else
+    NULL,
+    NULL,
+    NULL,
+#endif
+
+    /* cl_khr_egl_image */
+    &clCreateFromEGLImageKHR_shutdown,
+    &clEnqueueAcquireEGLObjectsKHR_shutdown,
+    &clEnqueueReleaseEGLObjectsKHR_shutdown,
+
+    /* cl_khr_egl_event */
+    &clCreateEventFromEGLSyncKHR_shutdown,
+
+    /* OpenCL 2.0 */
+    &clCreateCommandQueueWithProperties_shutdown,
+    &clCreatePipe_shutdown,
+    &clGetPipeInfo_shutdown,
+    &clSVMAlloc_shutdown,
+    &clSVMFree_shutdown,
+    &clEnqueueSVMFree_shutdown,
+    &clEnqueueSVMMemcpy_shutdown,
+    &clEnqueueSVMMemFill_shutdown,
+    &clEnqueueSVMMap_shutdown,
+    &clEnqueueSVMUnmap_shutdown,
+    &clCreateSamplerWithProperties_shutdown,
+    &clSetKernelArgSVMPointer_shutdown,
+    &clSetKernelExecInfo_shutdown,
+
+    /* cl_khr_sub_groups */
+    &clGetKernelSubGroupInfoKHR_shutdown,
+
+    /* OpenCL 2.1 */
+    &clCloneKernel_shutdown,
+    &clCreateProgramWithIL_shutdown,
+    &clEnqueueSVMMigrateMem_shutdown,
+    &clGetDeviceAndHostTimer_shutdown,
+    &clGetHostTimer_shutdown,
+    &clGetKernelSubGroupInfo_shutdown,
+    &clSetDefaultDeviceCommandQueue_shutdown,
+
+    /* OpenCL 2.2 */
+    &clSetProgramReleaseCallback_shutdown,
+    &clSetProgramSpecializationConstant_shutdown,
+
+    /* OpenCL 3.0 */
+    &clCreateBufferWithProperties_shutdown,
+    &clCreateImageWithProperties_shutdown,
+    &clSetContextDestructorCallback_shutdown,
+};
+
 #endif // defined(CL_ENABLE_LAYERS)
 
 #ifdef __cplusplus

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -182,6 +182,11 @@ static ${api.RetType} CL_API_CALL ${api.Name}_shutdown(
 %  endif
 %endfor
 {
+%for i, param in enumerate(api.Params):
+%  if param.Name != "" and param.Name != "errcode_ret":
+    (void)${param.Name};
+%  endif
+%endfor
 %if api.Name in ["clSVMFree"]:
     // Nothing!
 %elif api.Name in ["clSVMAlloc", "clGetExtensionFunctionAddress", "clGetExtensionFunctionAddressForPlatform"]:
@@ -305,6 +310,11 @@ static ${api.RetType} CL_API_CALL ${api.Name}_shutdown(
 %  endif
 %endfor
 {
+%for i, param in enumerate(api.Params):
+%  if param.Name != "" and param.Name != "errcode_ret":
+    (void)${param.Name};
+%  endif
+%endfor
 %if api.RetType in apihandles:
     KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
 %else:

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -47,10 +47,9 @@ apihandles = {
 extern "C" {
 #endif
 
-///////////////////////////////////////////////////////////////////////////////
-// Core APIs:
 %for apis in coreapis.values():
 %for api in apis:
+///////////////////////////////////////////////////////////////////////////////
 %if not api.Name in apiskip:
 <%
       handle = api.Params[0]
@@ -158,9 +157,9 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 #endif // defined(CL_ENABLE_LAYERS)
 %  endif
 
-///////////////////////////////////////////////////////////////////////////////
 %endfor
 %else:
+
 #if defined(CL_ENABLE_LAYERS)
 extern ${api.RetType} CL_API_CALL ${api.Name + "_disp"}(
 %for i, param in enumerate(api.Params):
@@ -171,6 +170,7 @@ extern ${api.RetType} CL_API_CALL ${api.Name + "_disp"}(
 %  endif
 %endfor
 #endif // defined(CL_ENABLE_LAYERS)
+
 %endif
 %endfor
 %endfor
@@ -195,12 +195,14 @@ win32extensions = {
 %for extension in icdextensions:
 <%
     apis = extapis[extension]
-%>// ${extension}
+%>
 %if extension in win32extensions:
-
 #if defined(_WIN32)
+
 %endif
 %for api in apis:
+///////////////////////////////////////////////////////////////////////////////
+// ${extension}
 <%
       handle = api.Params[0]
       if handle.Type in apihandles:
@@ -210,6 +212,7 @@ win32extensions = {
 %>
 %for disp in [0, 1]:
 %  if disp == 1:
+
 #if defined(CL_ENABLE_LAYERS)
 %  endif
 ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("", "_disp")[disp]}(
@@ -267,17 +270,16 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 }
 %  if disp == 1:
 #endif // defined(CL_ENABLE_LAYERS)
+
 %  endif
 %endfor
 %endfor
-
 %if extension in win32extensions:
 #endif // defined(_WIN32)
-
 %endif
+%endfor
 ///////////////////////////////////////////////////////////////////////////////
 
-%endfor
 #if defined(CL_ENABLE_LAYERS)
 struct _cl_icd_dispatch khrMasterDispatch = {
     &clGetPlatformIDs_disp,
@@ -484,6 +486,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clSetContextDestructorCallback_disp
 };
 #endif // defined(CL_ENABLE_LAYERS)
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -158,6 +158,28 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 %  endif
 
 %endfor
+#if defined(CL_ENABLE_LAYERS)
+static ${api.RetType} CL_API_CALL ${api.Name}_shutdown(
+%for i, param in enumerate(api.Params):
+%  if i < len(api.Params)-1:
+    ${param.Type} ${param.Name}${param.TypeEnd},
+%  else:
+    ${param.Type} ${param.Name}${param.TypeEnd})
+%  endif
+%endfor
+{
+%if api.Name == "clUnloadCompiler" or api.Name == "clSVMFree":
+    // Nothing!
+%elif api.Name == "clSVMAlloc" or api.Name == "clGetExtensionFunctionAddressForPlatform":
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, NULL);
+%elif api.RetType in apihandles or api.RetType == "void*":
+    KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(NULL, CL_INVALID_OPERATION);
+%else:
+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(NULL, CL_INVALID_OPERATION);
+%endif
+}
+#endif // defined(CL_ENABLE_LAYERS)
+
 %else:
 
 #if defined(CL_ENABLE_LAYERS)
@@ -358,7 +380,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clEnqueueReleaseGLObjects_disp,
     &clGetGLContextInfoKHR_disp,
 
-  /* cl_khr_d3d10_sharing */
+    /* cl_khr_d3d10_sharing */
 #if defined(_WIN32)
     &clGetDeviceIDsFromD3D10KHR_disp,
     &clCreateFromD3D10BufferKHR_disp,
@@ -375,7 +397,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     NULL,
 #endif
 
-  /* OpenCL 1.1 */
+    /* OpenCL 1.1 */
     &clSetEventCallback_disp,
     &clCreateSubBuffer_disp,
     &clSetMemObjectDestructorCallback_disp,
@@ -385,15 +407,15 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clEnqueueWriteBufferRect_disp,
     &clEnqueueCopyBufferRect_disp,
 
-  /* cl_ext_device_fission */
+    /* cl_ext_device_fission */
     &clCreateSubDevicesEXT_disp,
     &clRetainDeviceEXT_disp,
     &clReleaseDeviceEXT_disp,
 
-  /* cl_khr_gl_event */
+    /* cl_khr_gl_event */
     &clCreateEventFromGLsyncKHR_disp,
 
-  /* OpenCL 1.2 */
+    /* OpenCL 1.2 */
     &clCreateSubDevices_disp,
     &clRetainDevice_disp,
     &clReleaseDevice_disp,
@@ -411,7 +433,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clGetExtensionFunctionAddressForPlatform_disp,
     &clCreateFromGLTexture_disp,
 
-  /* cl_khr_d3d11_sharing */
+    /* cl_khr_d3d11_sharing */
 #if defined(_WIN32)
     &clGetDeviceIDsFromD3D11KHR_disp,
     &clCreateFromD3D11BufferKHR_disp,
@@ -430,7 +452,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     NULL,
 #endif
 
-  /* cl_khr_dx9_media_sharing */
+    /* cl_khr_dx9_media_sharing */
 #if defined(_WIN32)
     &clGetDeviceIDsFromDX9MediaAdapterKHR_disp,
     &clEnqueueAcquireDX9MediaSurfacesKHR_disp,
@@ -441,15 +463,15 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     NULL,
 #endif
 
-  /* cl_khr_egl_image */
+    /* cl_khr_egl_image */
     &clCreateFromEGLImageKHR_disp,
     &clEnqueueAcquireEGLObjectsKHR_disp,
     &clEnqueueReleaseEGLObjectsKHR_disp,
 
-  /* cl_khr_egl_event */
+    /* cl_khr_egl_event */
     &clCreateEventFromEGLSyncKHR_disp,
 
-  /* OpenCL 2.0 */
+    /* OpenCL 2.0 */
     &clCreateCommandQueueWithProperties_disp,
     &clCreatePipe_disp,
     &clGetPipeInfo_disp,
@@ -464,10 +486,10 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clSetKernelArgSVMPointer_disp,
     &clSetKernelExecInfo_disp,
 
-  /* cl_khr_sub_groups */
+    /* cl_khr_sub_groups */
     &clGetKernelSubGroupInfoKHR_disp,
 
-  /* OpenCL 2.1 */
+    /* OpenCL 2.1 */
     &clCloneKernel_disp,
     &clCreateProgramWithIL_disp,
     &clEnqueueSVMMigrateMem_disp,
@@ -476,14 +498,14 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clGetKernelSubGroupInfo_disp,
     &clSetDefaultDeviceCommandQueue_disp,
 
-  /* OpenCL 2.2 */
+    /* OpenCL 2.2 */
     &clSetProgramReleaseCallback_disp,
     &clSetProgramSpecializationConstant_disp,
 
-  /* OpenCL 3.0 */
+    /* OpenCL 3.0 */
     &clCreateBufferWithProperties_disp,
     &clCreateImageWithProperties_disp,
-    &clSetContextDestructorCallback_disp
+    &clSetContextDestructorCallback_disp,
 };
 #endif // defined(CL_ENABLE_LAYERS)
 


### PR DESCRIPTION
This is a proposed solution to address #157.  It adds an ICD loader extension that can be explicitly called by the host application (or possibly a layer?) to shut down and free memory.

I'm calling this WIP for now as I would like feedback in a few areas:

1. How thorough do we want the shutdown to be?  Specifically, do we want to unload the ICDs by closing the library handles, or do we only want to free ICD loader memory?  Do we want options to do both?
2. Do we want to add any sort of "stub layer" that causes subsequent OpenCL API calls to return an error code as part of the shutdown?  This seems to be working in the current POC, though note it will only be possible to do this for core OpenCL APIs and it will not be possible to stub OpenCL extension APIs.
3. How thread safe does this need to be?  Specifically, do we need to handle the case where the ICD loader shuts down while other OpenCL calls are being made from other threads?
4. Should we also provide a mechanism to "re-initialize" the ICD loader after shutting down or do we only need to support a single shutdown?
5. How do we want to test this?

I'll write up an "extension spec" for this when it's a bit further along but I'd like to work through some of these details first.  Thanks!