### PR TITLE
Explicitly mark compareLayer as __cdecl

### DIFF
--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -109,7 +109,7 @@ static WinLayer* pWinLayerBegin;
 static WinLayer* pWinLayerEnd;
 static WinLayer* pWinLayerCapacity;
 
-static int compareLayer(const void *a, const void *b)
+static int __cdecl compareLayer(const void *a, const void *b)
 {
     return ((WinLayer *)a)->priority < ((WinLayer *)b)->priority ? -1 :
            ((WinLayer *)a)->priority > ((WinLayer *)b)->priority ? 1 : 0;


### PR DESCRIPTION
There's command-line switches which can change the default calling convention for unannotated functions. Visual Studio defaults to `/Gd` which is `__cdecl`, but Windows defaults to `/Gz` which is `__stdcall`. That causes an x86 build break, since `qsort` requires the input parameter to be `__cdecl`. Just add the explicit annotation so it works regardless of the default.