### PR TITLE
Fix memory leaks in loader_test.

### DIFF
--- a/test/driver_stub/cl.c
+++ b/test/driver_stub/cl.c
@@ -1835,11 +1835,13 @@ clEnqueueNativeKernel(cl_command_queue   command_queue ,
     return return_value;
 }
 
+static void extFunc(void) { }
+
 CL_API_ENTRY void * CL_API_CALL
 clGetExtensionFunctionAddressForPlatform(cl_platform_id  platform ,
                                          const char *    func_name) CL_API_SUFFIX__VERSION_1_2
 {
-    void *return_value = (void *) malloc(sizeof(void *));
+    void *return_value = (void *)(size_t)&extFunc;
     test_icd_stub_log("clGetExtensionFunctionAddressForPlatform(%p, %p)\n",
                       platform,
                       func_name);

--- a/test/loader_test/test_create_calls.c
+++ b/test/loader_test/test_create_calls.c
@@ -780,11 +780,15 @@ int test_create_calls()
 
     test_clCreateBuffer(clCreateBufferData);
 
+    test_clReleaseMemObject(clReleaseMemObjectData);
+
     test_clCreateBufferWithProperties(clCreateBufferWithPropertiesData);
 
     test_clCreateSubBuffer(clCreateSubBufferData);
 
     test_clCreateImage(clCreateImageData);
+
+    test_clReleaseMemObject(clReleaseMemObjectDataImage);
 
     test_clCreateImageWithProperties(clCreateImageWithPropertiesData);
 

--- a/test/loader_test/test_program_objects.c
+++ b/test/loader_test/test_program_objects.c
@@ -124,6 +124,7 @@ int test_clCompileProgram(const struct clCompileProgram_st *data)
 int test_clLinkProgram(const struct clLinkProgram_st *data)
 {
     cl_program program;
+    cl_int ret_val;
     test_icd_app_log("clLinkProgram(%p, %u, %p, %p, %u, %p, %p, %p, %p)\n",
                      context,
                      data->num_devices,
@@ -146,6 +147,10 @@ int test_clLinkProgram(const struct clLinkProgram_st *data)
                         data->errcode_ret);
 
     test_icd_app_log("Value returned: %p\n", program);
+
+    test_icd_app_log("clReleaseProgram(%p)\n", program);
+    ret_val = clReleaseProgram(program);
+    test_icd_app_log("Value returned: %d\n", ret_val);
 
     return 0;
 


### PR DESCRIPTION
I was playing with valgrind and found a couple of memory leaks in the loader test, this patch addresses these.