### PR TITLE
Disable gcc-11 on macos

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -560,7 +560,9 @@ jobs:
       matrix:
         C_COMPILER:
         - /usr/bin/clang
-        - gcc-11
+        # Disabled due to problems with __has_cpp_attribute
+        # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114007
+        # - gcc-11
         # Disabled due to problems with the __API_AVAILABLE macro
         # - gcc-13
         GEN:


### PR DESCRIPTION
Similar to https://github.com/KhronosGroup/OpenCL-CLHPP/pull/304, the CI is broken for the loader as well.

We should put a fixed gcc version a soon as it is made available to our CI infrastructure.