### PR TITLE
Fix transposed arguments to `calloc`

### DIFF
--- a/loader/icd.c
+++ b/loader/icd.c
@@ -279,7 +279,7 @@ void khrIcdLayerAdd(const char *libraryName)
         goto Done;
     }
 
-    layer = (struct KHRLayer*)calloc(sizeof(struct KHRLayer), 1);
+    layer = (struct KHRLayer*)calloc(1, sizeof(struct KHRLayer));
     if (!layer)
     {
         KHR_ICD_TRACE("failed to allocate memory\n");


### PR DESCRIPTION
The signature to calloc is `void *calloc(size_t nmemb, size_t size)`. gcc very helpfully caught this use and is now warning about it.

Good job, gcc!