### PR TITLE
feat: add compatibility support for QNX Neutrino

### DIFF
--- a/loader/icd_platform.h
+++ b/loader/icd_platform.h
@@ -19,7 +19,7 @@
 #ifndef _ICD_PLATFORM_H_
 #define _ICD_PLATFORM_H_
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__QNXNTO__)
 
 #define PATH_SEPARATOR  ':'
 #define DIRECTORY_SYMBOL '/'

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -187,7 +187,11 @@ static inline void khrIcdOsDirEnumerate(const char *path, const char *env,
                          break;
                     memcpy(nameCopy, dirEntry->d_name, sz);
                     dirElems[elemCount].d_name = nameCopy;
+#if defined(__QNXNTO__)
+                    dirElems[elemCount].d_type = _DEXTRA_FIRST(dirEntry)->d_type;
+#else
                     dirElems[elemCount].d_type = dirEntry->d_type;
+#endif
                     elemCount++;
                 }
                 qsort(dirElems, elemCount, sizeof(struct dirElem), compareDirElem);

--- a/loader/linux/icd_linux_envvars.c
+++ b/loader/linux/icd_linux_envvars.c
@@ -32,7 +32,7 @@ char *khrIcd_getenv(const char *name) {
 }
 
 char *khrIcd_secure_getenv(const char *name) {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__QNXNTO__)
     // Apple does not appear to have a secure getenv implementation.
     // The main difference between secure getenv and getenv is that secure getenv
     // returns NULL if the process is being run with elevated privileges by a normal user.


### PR DESCRIPTION
Based on [#149](https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/149)  

## Changes  
This pull request adds support for QNX in the ICD loader by making the following changes:  

- **Platform Definition**  
  - Added `__QNXNTO__` to `icd_platform.h` to properly define platform-specific path separators and directory symbols.  

- **Directory Enumeration Fix**  
  - QNX requires a different way to access `d_type` in directory entries. Adjusted `icd_linux.c` to use `_DEXTRA_FIRST(dirEntry)->d_type` when compiling for QNX.  

- **Environment Variable Handling**  
  - Updated `icd_linux_envvars.c` to treat QNX like macOS, as QNX does not have a `secure_getenv` implementation.  

## Testing  
These changes have been tested on **Qualcomm SA8155P and SA8295P** platforms:  

| Platform  | OS Version |  
|-----------|-----------|  
| SA8155P   | QNX 7.0, Android |  
| SA8295P   | QNX 7.1, Android |  

[QNX 7.0.0 _DEXTRA_FIRST reference](https://www.qnx.com/developers/docs/7.0.0/#com.qnx.doc.neutrino.lib_ref/topic/r/readdir.html)
[QNX 7.1 _DEXTRA_FIRST reference](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/r/readdir.html)
