### PR TITLE
use two-step casting to silence incompatible function type warning

### DIFF
--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -281,7 +281,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
     if (hDXGI)
     {
         IDXGIFactory* pFactory = NULL;
-        PFN_CREATE_DXGI_FACTORY pCreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)GetProcAddress(hDXGI, "CreateDXGIFactory");
+        PFN_CREATE_DXGI_FACTORY pCreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)(void*)GetProcAddress(hDXGI, "CreateDXGIFactory");
         if (pCreateDXGIFactory)
         {
             HRESULT hr = pCreateDXGIFactory(&IID_IDXGIFactory, (void **)&pFactory);

--- a/loader/windows/icd_windows_apppackage.c
+++ b/loader/windows/icd_windows_apppackage.c
@@ -44,7 +44,7 @@ bool khrIcdOsVendorsEnumerateAppPackage(void)
         return ret;
 
     PFN_GetPackagesByPackageFamily pGetPackagesByPackageFamily =
-        (PFN_GetPackagesByPackageFamily)GetProcAddress(h, "GetPackagesByPackageFamily");
+        (PFN_GetPackagesByPackageFamily)(void*)GetProcAddress(h, "GetPackagesByPackageFamily");
     if (!pGetPackagesByPackageFamily)
     {
         KHR_ICD_TRACE("GetProcAddress failed for GetPackagesByPackageFamily\n");
@@ -52,7 +52,7 @@ bool khrIcdOsVendorsEnumerateAppPackage(void)
     }
 
     PFN_GetPackagePathByFullName pGetPackagePathByFullName =
-        (PFN_GetPackagePathByFullName)GetProcAddress(h, "GetPackagePathByFullName");
+        (PFN_GetPackagePathByFullName)(void*)GetProcAddress(h, "GetPackagePathByFullName");
     if (!pGetPackagePathByFullName)
     {
         KHR_ICD_TRACE("GetProcAddress failed for GetPackagePathByFullName\n");

--- a/loader/windows/icd_windows_dxgk.c
+++ b/loader/windows/icd_windows_dxgk.c
@@ -46,13 +46,13 @@ bool khrIcdOsVendorsEnumerateDXGK(void)
 
         EnumAdapters.adapter_count = 0;
         EnumAdapters.adapters = NULL;
-        PFN_LoaderEnumAdapters2 pEnumAdapters2 = (PFN_LoaderEnumAdapters2)GetProcAddress(h, "D3DKMTEnumAdapters2");
+        PFN_LoaderEnumAdapters2 pEnumAdapters2 = (PFN_LoaderEnumAdapters2)(void*)GetProcAddress(h, "D3DKMTEnumAdapters2");
         if (!pEnumAdapters2)
         {
             KHR_ICD_TRACE("GetProcAddress failed for D3DKMTEnumAdapters2\n");
             goto out;
         }
-        PFN_LoaderQueryAdapterInfo pQueryAdapterInfo = (PFN_LoaderQueryAdapterInfo)GetProcAddress(h, "D3DKMTQueryAdapterInfo");
+        PFN_LoaderQueryAdapterInfo pQueryAdapterInfo = (PFN_LoaderQueryAdapterInfo)(void*)GetProcAddress(h, "D3DKMTQueryAdapterInfo");
         if (!pQueryAdapterInfo)
         {
             KHR_ICD_TRACE("GetProcAddress failed for D3DKMTQueryAdapterInfo\n");


### PR DESCRIPTION
Looks like a recent GitHub actions change caused our Windows CI builds to fail in the `clangcl` config due to `-Werror` and `-Wcast-function-type-mismatch`:

```
D:\a\OpenCL-ICD-Loader\OpenCL-ICD-Loader\loader\windows\icd_windows.c(284,54): error : cast from 'FARPROC' (aka 'long long (*)()') to 'PFN_CREATE_DXGI_FACTORY' (aka 'long (*)(const struct _GUID *const, void **)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch] [D:\a\OpenCL-ICD-Loader\OpenCL-ICD-Loader\build\OpenCL.vcxproj]
```

We can silence this warning with a two-step cast, e.g.

```c++
PFN_CREATE_DXGI_FACTORY pCreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)(void*)GetProcAddress(hDXGI, "CreateDXGIFactory");
```

We do this a couple of other places in the OpenCL ICD loader by casting through `size_t`, but I think casting through `void*` is more common.  If desired though, I can switch to `size_t`, or turn the other casts to `void*` for consistency.