### PR TITLE
Hide ICD-specific symbols from users

### DIFF
--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -303,9 +303,25 @@ static inline void* clGetExtensionFunctionAddressForPlatform_body(
     // to get the extension function address.
 
     KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, NULL);
+
+#define KHR_ICD_REJECT_EXTENSION_FUNCTION(name)                                \
+    do                                                                         \
+    {                                                                          \
+        if (!strcmp(function_name, #name))                                     \
+        {                                                                      \
+            return NULL;                                                       \
+        }                                                                      \
+    } while (0)
+
+    // Reject ICD-specific functions that could be misused by users
+    KHR_ICD_REJECT_EXTENSION_FUNCTION(clIcdGetPlatformIDsKHR);
+    KHR_ICD_REJECT_EXTENSION_FUNCTION(clIcdGetFunctionAddressForPlatformKHR);
+    KHR_ICD_REJECT_EXTENSION_FUNCTION(clIcdSetPlatformDispatchDataKHR);
+
     return KHR_ICD2_DISPATCH(platform)->clGetExtensionFunctionAddressForPlatform(
         platform,
         function_name);
+#undef KHR_ICD_REJECT_EXTENSION_FUNCTION
 }
 
 void* CL_API_CALL clGetExtensionFunctionAddressForPlatform_disp(


### PR DESCRIPTION
This addresses some aspects of https://github.com/KhronosGroup/OpenCL-Docs/issues/1378
`clGetExtensionFunctionForPlatform` will always return `NULL` if called with `function_name` set as one of the functions defined in the `cl_khr_icd` extension.
`clGetExtensionFunction` would not return icd specific symbols (unless the platform extension suffix is "KHR") so I don't think we need to do anything there, bu I  could be persuaded otherwise.