### PR TITLE
Fix nameless union initialization.

### DIFF
--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -6825,7 +6825,7 @@ static cl_int CL_API_CALL clGetKernelSubGroupInfoKHR_disp(
 
 #if defined(CL_ENABLE_LAYERS)
 struct _cl_icd_dispatch khrMasterDispatch = {
-    &clGetPlatformIDs_disp,
+    {&clGetPlatformIDs_disp},
     &clGetPlatformInfo_disp,
     &clGetDeviceIDs_disp,
     &clGetDeviceInfo_disp,
@@ -6856,7 +6856,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clRetainProgram_disp,
     &clReleaseProgram_disp,
     &clBuildProgram_disp,
-    &clUnloadCompiler_disp,
+    {&clUnloadCompiler_disp},
     &clGetProgramInfo_disp,
     &clGetProgramBuildInfo_disp,
     &clCreateKernel_disp,

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -280,7 +280,7 @@ ${("CL_API_ENTRY", "static")[disp]} ${api.RetType} CL_API_CALL ${api.Name + ("",
 %endfor
 #if defined(CL_ENABLE_LAYERS)
 struct _cl_icd_dispatch khrMasterDispatch = {
-    &clGetPlatformIDs_disp,
+    {&clGetPlatformIDs_disp},
     &clGetPlatformInfo_disp,
     &clGetDeviceIDs_disp,
     &clGetDeviceInfo_disp,
@@ -311,7 +311,7 @@ struct _cl_icd_dispatch khrMasterDispatch = {
     &clRetainProgram_disp,
     &clReleaseProgram_disp,
     &clBuildProgram_disp,
-    &clUnloadCompiler_disp,
+    {&clUnloadCompiler_disp},
     &clGetProgramInfo_disp,
     &clGetProgramBuildInfo_disp,
     &clCreateKernel_disp,


### PR DESCRIPTION
This should address the issue generated by https://github.com/KhronosGroup/OpenCL-Headers/pull/280.
If we want backward compatibility, we should do some version detection to address both cases.

Error was, for reference:
```
/__w/OpenCL-ICD-Loader/OpenCL-ICD-Loader/loader/icd_dispatch_generated.c:6828:5: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    &clGetPlatformIDs_disp,
    ^~~~~~~~~~~~~~~~~~~~~~
    {                     }
```