### PR TITLE
remove cl_khr_icd2.h from CMake sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/loader/icd_cmake_config.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/icd_cmake_config.h)
 
 set (OPENCL_ICD_LOADER_SOURCES
-    include/cl_khr_icd2.h
     loader/icd.c
     loader/icd.h
     loader/icd_version.h

--- a/test/driver_stub/CMakeLists.txt
+++ b/test/driver_stub/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set (OPENCL_DRIVER_STUB_SOURCES cl.c cl_ext.c cl_gl.c icd.c ${CMAKE_SOURCE_DIR}/include/cl_khr_icd2.h)
+set (OPENCL_DRIVER_STUB_SOURCES cl.c cl_ext.c cl_gl.c icd.c)
 
 if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     list (APPEND OPENCL_DRIVER_STUB_SOURCES driver_stub.def)


### PR DESCRIPTION
We should only need to list source files that are compiled in the CMake sources, and do not need to list header files.  This fixes a build error in the OpenCL SDK CI.