### PR TITLE
Make android paths easier to override

### DIFF
--- a/loader/icd_platform.h
+++ b/loader/icd_platform.h
@@ -24,8 +24,12 @@
 #define PATH_SEPARATOR  ':'
 #define DIRECTORY_SYMBOL '/'
 #ifdef __ANDROID__
+#ifndef ICD_VENDOR_PATH
 #define ICD_VENDOR_PATH "/system/vendor/Khronos/OpenCL/vendors"
+#endif // ICD_VENDOR_PATH
+#ifndef LAYER_PATH
 #define LAYER_PATH "/system/vendor/Khronos/OpenCL/layers"
+#endif // LAYER_PATH
 #else
 #define ICD_VENDOR_PATH "/etc/OpenCL/vendors"
 #define LAYER_PATH "/etc/OpenCL/layers"


### PR DESCRIPTION
At the moment, the OpenCL-ICD-Loader checkout in android is using a patch to override the vendor/layer paths staticaly in the source code.

This patch aims at dropping that patch in android. It also moves the overload to the build system file (Soong's blueprint for android) instead of having it staticaly inline in the source code.

https://android.googlesource.com/platform/external/OpenCL-ICD-Loader/+/refs/heads/main/loader/icd_platform.h