### PR TITLE
[Important] Adds advanced flake.nix for $ nix build github:KhronosGroup/OpenCL-ICD-Loader and more

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{
+  description = "Development environment & packaging for OpenCL-ICD-Loader";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in rec {
+        checks.default = self.packages.${system}.default;
+        checks.pkg-config = self.packages.${system}.default.passthru.tests.pkg-config;
+        checks.cllayerinfo = self.packages.${system}.default.passthru.tests.cllayerinfo;
+
+        packages.default = pkgs.stdenv.mkDerivation (finalAttrs: rec {
+          name = "opencl-icd-loader";
+          nativeBuildInputs = [ pkgs.cmake pkgs.opencl-headers ];
+
+          src = ./.;
+
+          cmakeFlags = [
+            "-DOCL_ICD_ENABLE_TRACE=ON"
+          ];
+
+          doCheck = true;
+
+          passthru.tests = with pkgs; {
+            pkg-config = pkgs.testers.hasPkgConfigModules {
+              package = finalAttrs.finalPackage;
+              moduleNames = [ "OpenCL" ];
+            };
+            cllayerinfo = pkgs.testers.nixosTest {
+              name = "cllayerinfo-test";
+              nodes.machine = {
+                environment.systemPackages = [
+                  self.packages.${system}.default
+                ];
+              };
+
+              testScript = ''
+                start_all()
+                machine.succeed("cllayerinfo")
+              '';
+            };
+          };
+        });
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.pkg-config
+            self.packages.${system}.default.nativeBuildInputs
+            self.packages.${system}.default
+          ];
+
+          doCheck = false; # Disables automatically running tests for `$ nix develop` and direnv
+
+          shellHook = ''
+            export ZDOTDIR=$(mktemp -d)
+            cat > "$ZDOTDIR/.zshrc" << 'EOF'
+              source ~/.zshrc # Source the original ~/.zshrc, required.
+
+              function parse_git_branch {
+                git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\ ->\ \1/'
+              }
+
+              function display_jobs_count_if_needed {
+                local job_count=$(jobs -s | wc -l | tr -d " ")
+
+                if [ $job_count -gt 0 ]; then
+                  echo "%B%F{yellow}%j| ";
+                fi
+              }
+
+              # NOTE: Custom prompt with a snowflake: signals we are in `$ nix develop` shell
+              PROMPT="%F{blue}$(date +%H:%M:%S) $(display_jobs_count_if_needed)%B%F{green}%n %F{blue}%~%F{cyan} ❄%F{yellow}$(parse_git_branch) %f%{$reset_color%}"
+            EOF
+
+            if [ -z "$DIRENV_IN_ENVRC" ]; then # This makes `$ nix develop` universally working with direnv without infinite loop
+              exec ${pkgs.zsh}/bin/zsh -i
+            fi
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Hi there,

Currently I'm working on standardizing, further specifying and simplifying the build, test and release of all the GPU based software for nix: which should eventually allow all standard bodies and hardware/software vendors to further standardize their build workflows.

We already have `khronos-ocl-icd-loader` on nixpkgs here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/kh/khronos-ocl-icd-loader/package.nix

This `flake.nix` serves as an additional release channel for a direct specific github branch on any machine that has `nix` via:

```zsh
$ nix build github:KhronosGroup/OpenCL-ICD-Loader # or:
$ nix build github:KhronosGroup/OpenCL-ICD-Loader/ad770a1b64c6b8d5f2ed4e153f22e4f45939f27f # or:
$ nix build github:KhronosGroup/OpenCL-ICD-Loader/v2025.07.22
```

Also serves as a further documentation as code for all the important build targets.

It also standardizes the builds under a single command:

```zsh
$ nix build ".#" # Runs the unit tests as well, nix testing convention, there is doCheck = true
$ tree ./result
result
├── bin
│   └── cllayerinfo
├── lib
│   ├── libOpenCL.so -> libOpenCL.so.1
│   ├── libOpenCL.so.1 -> libOpenCL.so.1.0.0
│   ├── libOpenCL.so.1.0.0
│   └── pkgconfig
│       └── OpenCL.pc
└── share
    └── cmake
        └── OpenCLICDLoader
            ├── OpenCLICDLoaderConfig.cmake
            ├── OpenCLICDLoaderConfigVersion.cmake
            ├── OpenCLICDLoaderTargets.cmake
            └── OpenCLICDLoaderTargets-release.cmake

7 directories, 9 files
```

A contributor can have standardized development environment via:

```zsh
$ nix develop # Could also automatically if the developer has `direnv` installed & configured
# With the current flake.nix, then developer can see the output:
$ pkg-config --list-all --cflags
OpenCL-Headers OpenCL-Headers - Khronos OpenCL Headers
OpenCL         OpenCL - Khronos OpenCL ICD Loader
```

Lastly, in the future, if there is enough interest, this could enhance the existing CI workflow(with additional PRs) via: 

```zsh
$ nix flake check --all-systems # Runs all the checks(unit tests, pkg-config checks etc) on all CPU architectures
````

On a corollary note, I suggest all software developers to install and use nix for all its benefits. I think there is enough documentation online, however I currently find the documentation lacking for conventions around testing. So I documented it here for the ones interested:  https://gist.github.com/izelnakri/06d7286fe9ab5f15acee9cbeace1c1b1