### PR TITLE
Add static link libs to OpenCL.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set_target_properties (OpenCL PROPERTIES VERSION 1\.0\.0 SOVERSION "1")
 
 if (WIN32)
     target_link_libraries (OpenCL PRIVATE cfgmgr32.lib runtimeobject.lib)
+    string(APPEND OPENCL_LIBS_PRIVATE_PC " -lcfgmgr32 -lruntimeobject")
 
     # Generate a DLL without a "lib" prefix for mingw.
     if (MINGW OR MSYS OR CYGWIN)
@@ -135,6 +136,7 @@ if (WIN32)
     endif()
 else()
     target_link_libraries (OpenCL PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+    string(APPEND OPENCL_LIBS_PRIVATE_PC " ${CMAKE_THREAD_LIBS_INIT}")
     if (NOT APPLE)
         set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/loader/linux/icd_exports.map")
         if (OPENCL_ICD_LOADER_PIC)
@@ -177,6 +179,9 @@ target_include_directories (OpenCL
     loader
 )
 target_link_libraries (OpenCL PUBLIC ${CMAKE_DL_LIBS})
+if(CMAKE_DL_LIBS STREQUAL "dl")
+  string(APPEND OPENCL_LIBS_PRIVATE_PC " -ldl")
+endif()
 
 if (ENABLE_OPENCL_LAYERINFO)
 
@@ -297,3 +302,4 @@ install (TARGETS OpenCL
       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT dev
     NAMELINK_ONLY)
+install_opencl_pc()

--- a/OpenCL.pc.in
+++ b/OpenCL.pc.in
@@ -7,3 +7,4 @@ Description: Khronos OpenCL ICD Loader
 Requires: OpenCL-Headers
 Version: 3.0
 Libs: -L${libdir} -lOpenCL
+Libs.private:@OPENCL_LIBS_PRIVATE_PC@

--- a/cmake/Package.cmake
+++ b/cmake/Package.cmake
@@ -12,28 +12,32 @@ join_paths(OPENCL_LIBDIR_PC "\${exec_prefix}" "${CMAKE_INSTALL_LIBDIR}")
 set(pkg_config_location ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 set(PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}")
 
-# Configure and install OpenCL.pc for installing the project
-configure_file(
-  OpenCL.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_install/OpenCL.pc
-  @ONLY)
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_install/OpenCL.pc
-  DESTINATION ${pkg_config_location}
-  COMPONENT pkgconfig_install)
+set(OPENCL_LIBS_PRIVATE_PC "")
 
-# Configure and install OpenCL.pc for the Debian package
-set(PKGCONFIG_PREFIX "${CPACK_PACKAGING_INSTALL_PREFIX}")
-configure_file(
-  OpenCL.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_package/OpenCL.pc
-  @ONLY)
+function(install_opencl_pc)
+  # Configure and install OpenCL.pc for installing the project
+  configure_file(
+    OpenCL.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_install/OpenCL.pc
+    @ONLY)
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_install/OpenCL.pc
+    DESTINATION ${pkg_config_location}
+    COMPONENT pkgconfig_install)
 
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_package/OpenCL.pc
-  DESTINATION ${pkg_config_location}
-  COMPONENT dev
-  EXCLUDE_FROM_ALL)
+  # Configure and install OpenCL.pc for the Debian package
+  set(PKGCONFIG_PREFIX "${CPACK_PACKAGING_INSTALL_PREFIX}")
+  configure_file(
+    OpenCL.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_package/OpenCL.pc
+    @ONLY)
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig_package/OpenCL.pc
+    DESTINATION ${pkg_config_location}
+    COMPONENT dev
+    EXCLUDE_FROM_ALL)
+endfunction()
 
 set(CPACK_DEBIAN_PACKAGE_DEBUG ON)
 


### PR DESCRIPTION
This is a (variation of) a patch added to the vcpkg port in order to fix downstream tests of ggml/whisper.cpp/llama.cpp with static library linkage.
- Static link libs are collected in `OPENCL_LIBS_PRIVATE_PC` and exported in the `Libs.private` field. This field is used by `pkg-config --static`.
- The generation of the pc file now takes place after configuring the OpenCL target.
- For `CMAKE_DL_LIBS`, only `dl` and the emtpy value are handled.