### PR TITLE
Switch to __CL_HAS_ANON_UNION__ macro

### DIFF
--- a/loader/icd.h
+++ b/loader/icd.h
@@ -182,7 +182,7 @@ void khrIcdContextPropertiesGetPlatform(
     cl_platform_id *outPlatform);
 
 // condition anonyous union initialization to usage
-#if __CL_HAS_ANON_STRUCT__
+#if __CL_HAS_ANON_UNION__
 #define ICD_ANON_UNION_INIT_MEMBER(a) {a}
 #else
 #define ICD_ANON_UNION_INIT_MEMBER(a) a


### PR DESCRIPTION
Update loader to use __CL_HAS_ANON_UNION__ macro introduced in https://github.com/KhronosGroup/OpenCL-Headers/pull/293