### PR TITLE
update copyright dates to 2026

### DIFF
--- a/include/cl_khr_icd2.h
+++ b/include/cl_khr_icd2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/cllayerinfo.c
+++ b/loader/cllayerinfo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 The Khronos Group Inc.
+ * Copyright (c) 2022-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd.c
+++ b/loader/icd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd_dispatch.c
+++ b/loader/icd_dispatch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020 The Khronos Group Inc.
+ * Copyright (c) 2012-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd_dispatch.h
+++ b/loader/icd_dispatch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd_dispatch_generated.c
+++ b/loader/icd_dispatch_generated.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 The Khronos Group Inc.
+ * Copyright (c) 2012-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd_envvars.h
+++ b/loader/icd_envvars.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd_platform.h
+++ b/loader/icd_platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/icd_version.h
+++ b/loader/icd_version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/linux/icd_exports.map
+++ b/loader/linux/icd_exports.map
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/linux/icd_linux_envvars.c
+++ b/loader/linux/icd_linux_envvars.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/OpenCL-mingw-i686.def
+++ b/loader/windows/OpenCL-mingw-i686.def
@@ -1,5 +1,5 @@
 ;
-; Copyright (c) 2022 The Khronos Group Inc.
+; Copyright (c) 2022-2026 The Khronos Group Inc.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.

--- a/loader/windows/OpenCL.def
+++ b/loader/windows/OpenCL.def
@@ -1,5 +1,5 @@
 ;
-; Copyright (c) 2016-2019 The Khronos Group Inc.
+; Copyright (c) 2016-2026 The Khronos Group Inc.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.

--- a/loader/windows/OpenCL.rc
+++ b/loader/windows/OpenCL.rc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ BEGIN
         BEGIN
             VALUE "FileDescription" ,"OpenCL Client DLL"
             VALUE "ProductName"     ,OPENCL_ICD_LOADER_NAME_STRING
-            VALUE "LegalCopyright"  ,L"Copyright \251 The Khronos Group Inc 2016-2023"
+            VALUE "LegalCopyright"  ,L"Copyright \251 The Khronos Group Inc 2016-2026"
             VALUE "FileVersion"     ,OPENCL_ICD_LOADER_VERSION_STRING ".0"
             VALUE "CompanyName"     ,OPENCL_ICD_LOADER_VENDOR_STRING
             VALUE "InternalName"    ,"OpenCL"

--- a/loader/windows/adapter.h
+++ b/loader/windows/adapter.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 The Khronos Group Inc.
+* Copyright (c) 2019-2026 The Khronos Group Inc.
 * Copyright (c) 2019 Valve Corporation
 * Copyright (c) 2019 LunarG, Inc.
 *

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows.h
+++ b/loader/windows/icd_windows.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_apppackage.c
+++ b/loader/windows/icd_windows_apppackage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_apppackage.h
+++ b/loader/windows/icd_windows_apppackage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_dxgk.c
+++ b/loader/windows/icd_windows_dxgk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_dxgk.h
+++ b/loader/windows/icd_windows_dxgk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_envvars.c
+++ b/loader/windows/icd_windows_envvars.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 The Khronos Group Inc.
+ * Copyright (c) 2016-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_hkr.c
+++ b/loader/windows/icd_windows_hkr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/windows/icd_windows_hkr.h
+++ b/loader/windows/icd_windows_hkr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 The Khronos Group Inc.
+ * Copyright (c) 2017-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/gen/__init__.py
+++ b/scripts/gen/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2020-2026 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/gen_loader.py
+++ b/scripts/gen_loader.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2020-2026 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/gen_print_layer.py
+++ b/scripts/gen_print_layer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2020-2026 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/icd_dispatch_generated.c.mako
+++ b/scripts/icd_dispatch_generated.c.mako
@@ -26,7 +26,7 @@ apihandles = {
 
 table_template = Template(filename='dispatch_table.mako')
 %>/*
- * Copyright (c) 2012-2023 The Khronos Group Inc.
+ * Copyright (c) 2012-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/icd_print_layer_generated.c.mako
+++ b/scripts/icd_print_layer_generated.c.mako
@@ -2,7 +2,7 @@
 from mako.template import Template
 table_template = Template(filename='dispatch_table.mako')
 %>/*
- * Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/layer/icd_print_layer.c
+++ b/test/layer/icd_print_layer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/layer/icd_print_layer.h
+++ b/test/layer/icd_print_layer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/layer/icd_print_layer_generated.c
+++ b/test/layer/icd_print_layer_generated.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates OpenCL ICD loader copyright dates to 2026.