### PR TITLE
Prevent windows library unloading at process termination.

### DIFF
--- a/loader/cllayerinfo.c
+++ b/loader/cllayerinfo.c
@@ -121,6 +121,15 @@ static void run_silently(void (*pfn)(void))
     atexit(silence_layers);
 }
 
+static void run_silently_int(void (*pfn)(int), int arg)
+{
+    silence_layers();
+    atexit(restore_outputs);
+    pfn(arg);
+    restore_outputs();
+    atexit(silence_layers);
+}
+
 int main (int argc, char *argv[])
 {
     (void)argc;
@@ -132,6 +141,6 @@ int main (int argc, char *argv[])
         printLayerInfo(layer);
         layer = layer->next;
     }
-    run_silently(&khrIcdDeinitialize);
+    run_silently_int(&khrIcdDeinitialize, 1);
     return 0;
 }

--- a/loader/icd.c
+++ b/loader/icd.c
@@ -584,13 +584,12 @@ void khrIcdContextPropertiesGetPlatform(const cl_context_properties *properties,
 static struct KHRLayer deinitLayer = {0};
 #endif
 
-void khrIcdDeinitialize(void) {
+void khrIcdDeinitialize(int unloadLibraries) {
     if (khrForceLegacyTermination)
     {
         KHR_ICD_TRACE("ICD Loader deinitialization disabled\n");
         return;
     }
-
     KHR_ICD_TRACE("ICD Loader deinitialization\n");
 
 #if defined(CL_ENABLE_LAYERS)
@@ -614,7 +613,7 @@ void khrIcdDeinitialize(void) {
                 KHR_ICD_TRACE("error reported in layer deinitialization\n");
             }
         }
-        if (!khrDisableLibraryUnloading)
+        if (unloadLibraries && !khrDisableLibraryUnloading)
             khrIcdOsLibraryUnload(cur->library);
         head = cur->next;
         free(cur);
@@ -626,7 +625,7 @@ void khrIcdDeinitialize(void) {
     while (lastVendor) {
         KHRicdVendor *cur = lastVendor;
         free(cur->suffix);
-        if (cur->unloadable && !khrDisableLibraryUnloading)
+        if (cur->unloadable && unloadLibraries && !khrDisableLibraryUnloading)
             khrIcdOsLibraryUnload(cur->library);
         lastVendor = cur->prev;
         free(cur);

--- a/loader/icd.h
+++ b/loader/icd.h
@@ -158,7 +158,7 @@ void khrIcdInitialize(void);
 void khrIcdInitializeEnvOptions(void);
 
 // entrypoint to release icd resources
-void khrIcdDeinitialize(void);
+void khrIcdDeinitialize(int unloadLibraries);
 
 // go through the list of vendors (in /etc/OpenCL.conf or through 
 // the registry) and call khrIcdVendorAdd for each vendor encountered

--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -239,6 +239,6 @@ void khrIcdOsVendorsEnumerateOnce(void)
 #ifndef CL_LAYER_INFO
 static
 void __attribute__((destructor)) khrIcdDestructor(void) {
-    khrIcdDeinitialize();
+    khrIcdDeinitialize(1);
 }
 #endif

--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -416,7 +416,7 @@ BOOL APIENTRY DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
     (void)hinst;
     (void)reserved;
     if (reason == DLL_PROCESS_DETACH) {
-        khrIcdDeinitialize();
+        khrIcdDeinitialize(reserved == NULL ? 1 : 0);
     }
     return TRUE;
 }


### PR DESCRIPTION
DLL unloading at process de-initialization should be avoided:

> Similarly, the entry-point function must not call the [FreeLibrary](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-freelibrary) function (or a function that calls FreeLibrary) during process termination, because this can result in a DLL being used after the system has executed its termination code.

https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain