### PR TITLE
update Windows CI for new runners

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -238,7 +238,7 @@ jobs:
     strategy:
       matrix:
         VER: [v142, v143, clangcl]
-        GEN: [Visual Studio 17 2022, Ninja Multi-Config]
+        GEN: [Visual Studio 18 2026, Ninja Multi-Config]
         BIN: [x64]
         CMAKE_C_EXTENSIONS:
         - OFF
@@ -248,13 +248,10 @@ jobs:
           GEN: Ninja Multi-Config
         include:
         - VER: v142
-          GEN: Visual Studio 17 2022
+          GEN: Visual Studio 18 2026
           BIN: x86
           CMAKE_C_EXTENSIONS: ON
     env:
-      NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
-      NINJA_ROOT: C:\Tools\Ninja
-      VS_ROOT: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise'
       UseMultiToolTask: true # Better parallel MSBuild execution
       EnforceProcessCountAcrossBuilds: 'true'
       MultiProcMaxCount: '3'
@@ -264,21 +261,29 @@ jobs:
       CFLAGS: /W4 /WX /wd4152 /wd4201 /wd4310
 
     steps:
-    - name: Cache Ninja install
-      if: matrix.GEN == 'Ninja Multi-Config'
-      id: ninja-install
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: |
-          C:\Tools\Ninja
-        key: ${{runner.os}}-ninja-${{env.NINJA_URL}}
-
-    - name: Install Ninja
-      if: matrix.GEN == 'Ninja Multi-Config' && steps.ninja-install.outputs.cache-hit != 'true'
+    - name: Resolve Visual Studio install path
       run: |
-        Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
-        Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath ${env:NINJA_ROOT}\
-        Remove-Item ~\Downloads\*
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (!(Test-Path $vswhere)) { throw "vswhere is not available on this runner." }
+
+        $versionRange = if ('${{matrix.GEN}}' -eq 'Visual Studio 18 2026') { '[18.0,19.0)' } else { '[0.0,99.0)' }
+        $vsPath = & $vswhere `
+          -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -version $versionRange `
+          -latest `
+          -property installationPath
+
+        if (-not $vsPath) {
+          $vsPath = & $vswhere `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -latest `
+            -property installationPath
+        }
+
+        if (-not $vsPath) { throw "No suitable Visual Studio installation was found." }
+        "VS_ROOT=$vsPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Checkout OpenCL-ICD-Loader
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -290,7 +295,7 @@ jobs:
         path: external/OpenCL-Headers
 
     - name: Build & install OpenCL-Headers (MSBuild)
-      if: matrix.GEN == 'Visual Studio 17 2022'
+      if: matrix.GEN == 'Visual Studio 18 2026'
       run: |
         $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
         & cmake `
@@ -322,7 +327,7 @@ jobs:
         Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=$VER"
         & cmake `
           -G "${{matrix.GEN}}" `
-          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe"  `
+          -D CMAKE_MAKE_PROGRAM=ninja `
           -D BUILD_TESTING=OFF `
           -D CMAKE_C_EXTENSIONS=${{matrix.CMAKE_C_EXTENSIONS}} `
           -D CMAKE_INSTALL_PREFIX=${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install `
@@ -337,7 +342,7 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "Building OpenCL-Headers failed." }
 
     - name: Configure (MSBuild)
-      if: matrix.GEN == 'Visual Studio 17 2022'
+      if: matrix.GEN == 'Visual Studio 18 2026'
       run: |
         $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
         & cmake `
@@ -362,7 +367,7 @@ jobs:
         Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=$VER"
         & cmake `
           -G "${{matrix.GEN}}" `
-          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D CMAKE_MAKE_PROGRAM=ninja `
           -D BUILD_TESTING=ON `
           -D CMAKE_C_EXTENSIONS=${{matrix.CMAKE_C_EXTENSIONS}} `
           -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
@@ -373,7 +378,7 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "Configuring OpenCL-ICD-Loader failed." }
 
     - name: Build (MSBuild)
-      if: matrix.GEN == 'Visual Studio 17 2022'
+      if: matrix.GEN == 'Visual Studio 18 2026'
       run: |
         foreach ($Config in 'Release','Debug') {
           & cmake `
@@ -432,7 +437,7 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "Installing OpenCL-ICD-Loader failed." }
 
     - name: "Consume (MSBuild standalone): Configure/Build/Test"
-      if: matrix.GEN == 'Visual Studio 17 2022'
+      if: matrix.GEN == 'Visual Studio 18 2026'
       run: |
         $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
         & cmake `
@@ -478,7 +483,7 @@ jobs:
         Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=$VER"
         & cmake `
           -G '${{matrix.GEN}}' `
-          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D CMAKE_MAKE_PROGRAM=ninja `
           -D CMAKE_C_EXTENSIONS=${{matrix.CMAKE_C_EXTENSIONS}} `
           -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
           -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install" `
@@ -515,7 +520,7 @@ jobs:
         New-Item -Type File -Path ${env:GITHUB_WORKSPACE}\install\share\cmake\OpenCL\OpenCLConfig.cmake -Value "include(`"$workspace/external/OpenCL-Headers/install/share/cmake/OpenCLHeaders/OpenCLHeadersTargets.cmake`")`r`ninclude(`"`${CMAKE_CURRENT_LIST_DIR}/../OpenCLICDLoader/OpenCLICDLoaderTargets.cmake`")"
 
     - name: "Consume (MSBuild SDK): Configure/Build/Test"
-      if: matrix.GEN == 'Visual Studio 17 2022'
+      if: matrix.GEN == 'Visual Studio 18 2026'
       run: |
         $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
         & cmake `
@@ -561,7 +566,7 @@ jobs:
         Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=$VER"
         & cmake `
           -G '${{matrix.GEN}}' `
-          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D CMAKE_MAKE_PROGRAM=ninja `
           -D CMAKE_C_EXTENSIONS=${{matrix.CMAKE_C_EXTENSIONS}} `
           -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
           -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install" `


### PR DESCRIPTION
Looks like I didn't file an issue for this repo, but this is the same fix as for OpenCL-Headers and OpenCL-CLHPP.